### PR TITLE
feat: 랭킹 메인화면 UI 구현

### DIFF
--- a/src/features/search/screens/searchScreen.tsx
+++ b/src/features/search/screens/searchScreen.tsx
@@ -11,8 +11,8 @@ import {
 import { SafeAreaView } from "react-native-safe-area-context";
 import PassportFrame from "../components/PassportFrame";
 import SearchToggle from "../components/SearchToggle";
-import { searchUserDummy } from "../data/searchDummy";
-import { SearchTab } from "../types/search.types";
+import { rankingDummy, searchUserDummy } from "../data/searchDummy";
+import { RankingUser, SearchTab } from "../types/search.types";
 
 export default function SearchView() {
 
@@ -46,6 +46,7 @@ export default function SearchView() {
     )
 }
 
+{/*둘러보기 메인 화면*/}
 function AllSearchContent() {
     return(
         <View style={styles.card}>
@@ -85,10 +86,98 @@ function AllSearchContent() {
     )
 }
 
+{/*랭킹 메인화면*/}
 function RankingContent() {
+
+    const topThree = rankingDummy.slice(0, 3);
+    const rankingList = rankingDummy;
+
     return(
-        <Text>랭킹 페이지</Text>
+        <View>
+            <View style={styles.topRankingRow}>
+                {topThree.map((user) => (
+                    <TopRankingCard key={user.id} user={user} />
+                ))}
+            </View>
+
+            <View style={styles.rankingList}>
+                {rankingList.map((user) => (
+                    <RankingItem key={user.id} user={user} />
+                ))}
+            </View>
+        </View>
     )
+}
+
+{/*랭킹 Top3*/}
+function TopRankingCard({user}: {user: RankingUser}) {
+    return(
+        <View style={styles.topRankingCard}>
+            <Text style={styles.medalText}>{getMedal(user.rank)}</Text>
+            <Text style={styles.topRankingName}>{user.name}</Text>
+
+            <View style={styles.likeRow}>
+                <Ionicons name="heart-outline" size={12} color="#ED3838" />
+                <Text style={styles.topRankingLike}>{user.likeCount}개</Text>
+            </View>
+        </View>
+    )
+}
+
+{/*나머지 리스트*/}
+function RankingItem({user}: {user: RankingUser}) {
+    return(
+        <View style={styles.rankingItem}>
+            <View style={styles.rankCircle}>
+                <Text style={styles.rankText}>{user.rank}</Text>
+            </View>
+
+            <Image source={user.profileImage} style={styles.rankingProfileImage} />
+
+            <View style={styles.rankingUserInfo}>
+                <Text style={styles.rankingName}>{user.name}</Text>
+
+                <View style={styles.rankingLikeRow}>
+                    <Ionicons name="heart" size={12} color="#1A3A6B" />
+                    <Text style={styles.rankingLikeText}>{user.likeCount}개</Text>
+                </View>
+            </View>
+
+            {user.rank <= 3 && (
+                <View 
+                    style={[
+                        styles.trophyCircle,
+                        {backgroundColor: getTrophyBackgroundColor(user.rank)},
+                        ]}
+                >
+                    <Text style={styles.trophyText}>{getTrophy(user.rank)}</Text>
+                </View>
+            )}
+        </View>
+    )
+}
+
+{/*메달 얻는 함수*/}
+function getMedal(rank: number) {
+    if (rank === 1) return "🥇";
+    if (rank === 2) return "🥈";
+    if (rank === 3) return "🥉";
+    return "";
+}
+
+{/*트로피 얻는 함수*/}
+function getTrophy(rank: number) {
+    if (rank === 1) return "🏆";
+    if (rank === 2) return "🏆";
+    if (rank === 3) return "🏆";
+    return "";
+}
+
+{/*등수별 트로피 배경 색 얻는 함수*/}
+function getTrophyBackgroundColor(rank: number) {
+    if (rank === 1) return "#FFD700"; 
+    if (rank === 2) return "#C0C0C0";
+    if (rank === 3) return "#CD7F32"; 
 }
 
 const styles = StyleSheet.create({
@@ -182,4 +271,110 @@ const styles = StyleSheet.create({
     },
 
     // 랭킹
+    // 1. 랭킹 메인화면 & Top3
+    topRankingRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        marginBottom: 18,
+    },
+    topRankingCard: {
+        width: "31%",
+        height: 100,
+        backgroundColor: "#1A3A6B",
+        borderRadius: 15,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    medalText: {
+        fontSize: 20,
+        marginBottom: 4,   
+    },
+    topRankingName: {
+        fontSize: 16,
+        fontWeight: "600",
+        color: "#FFFFFF",
+        marginBottom: 2,
+    },
+    likeRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 3,
+    },
+    topRankingLike: {
+        fontSize: 12,
+        color: "#FFFFFF",
+        fontWeight: "500",
+    },
+
+    // 2. 나머지 리스트
+    rankingList: {
+        gap: 12,
+    },
+    rankingItem: {
+        height: 82,
+        backgroundColor: "#FFFFFF",
+        borderRadius: 15,
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 16,
+        shadowColor: "#000000",
+        shadowOpacity: 0.1,
+        shadowRadius: 5,
+        elevation: 3,
+    },
+    rankCircle: {
+        width: 40,
+        height: 40,
+        borderRadius: 20,
+        backgroundColor: "#1A3A6B",
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 12
+    },
+    rankText: {
+        fontSize: 18,
+        fontWeight: "600",
+        color: "#FFFFFF",
+    },
+    rankingProfileImage: {
+        width: 50,
+        height: 50,
+        borderRadius: 25,
+        backgroundColor: "#d9d9d9",
+        borderWidth: 2,
+        borderColor: "#1A3A6B",
+        marginRight: 12,
+    },
+    rankingUserInfo: {
+        flex: 1,
+    },
+    rankingName: {
+        fontSize: 16,
+        fontWeight: "500",
+        color: "#1A3A6B",
+        marginBottom: 4,
+    },
+    rankingLikeRow: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    rankingLikeText: {
+        marginLeft: 3,
+        fontSize: 13,
+        color: "#1A3A6B",
+        fontWeight: "500",
+    },
+
+    // 3. 트로피
+    trophyCircle: {
+        width: 30,
+        height: 30,
+        borderRadius: 20,
+        backgroundColor: "#F3F3F3",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    trophyText: {
+        fontSize: 15,
+    },
 });


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #21 

## 📝 작업 내용

### <방식>
- `searchDummy.ts`에서 랭킹 사용자 더미 데이터를 배열로 관리
- `search.types.ts`에서 `RankingUser` 타입을 정의하여 랭킹 데이터 구조 설정
- `SearchView.tsx` 내부에서 `RankingContent` 컴포넌트를 통해 랭킹 화면 구성
- `rankingDummy` 데이터를 `map()`으로 반복 출력하여 랭킹 리스트 생성
- 1등, 2등, 3등은 상단 랭킹 카드와 리스트의 트로피 영역에서 강조 표시

### <화면 흐름>

- `SearchView.tsx`
사용자가 `랭킹` 탭을 선택하면 `RankingContent`를 화면에 출력
- `RankingContentrankingDummy` 데이터를 불러와 상위 랭킹 영역과 전체 랭킹 리스트를 구성
- `TopRankingCard`
1등, 2등, 3등 사용자를 상단 카드 형태로 표시
- `RankingItem`
각 사용자의 순위, 프로필 이미지, 이름, 좋아요 개수를 리스트 형태로 표시
- `getTrophyBackgroundColor`
1등, 2등, 3등 트로피 배경색을 다르게 반환하여 순위별 UI 강조

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

