### PR TITLE
feat: 둘러보기 페이지 릴스 기능 UI 구현

### DIFF
--- a/src/features/search/components/PassportActionButtons.tsx
+++ b/src/features/search/components/PassportActionButtons.tsx
@@ -1,0 +1,46 @@
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+
+type PassportActionButtonsProps = {
+    isLiked: boolean;
+    isScrapped: boolean;
+    onPressLike: () => void;
+    onPressScrap: () => void;
+};
+
+export default function PassportActionButtons({
+    isLiked,
+    isScrapped,
+    onPressLike,
+    onPressScrap,
+}: PassportActionButtonsProps) {
+    return (
+        <View style={styles.actionButtonArea}>
+            <TouchableOpacity onPress={onPressLike}>
+                <Ionicons
+                    name={isLiked ? "heart" : "heart-outline"}
+                    size={24}
+                    color={isLiked ? "#ED3838" : "#333333"}
+                />
+            </TouchableOpacity>
+
+            <TouchableOpacity onPress={onPressScrap}>
+                <Ionicons
+                    name={isScrapped ? "bookmark" : "bookmark-outline"}
+                    size={24}
+                    color={isScrapped ? "#FFD233" : "#333333"}
+                />
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    actionButtonArea: {
+        position: "absolute",
+        top: 16,
+        right: 14,
+        zIndex: 20,
+        gap: 10,
+    },
+});

--- a/src/features/search/components/PassportFrame.tsx
+++ b/src/features/search/components/PassportFrame.tsx
@@ -1,13 +1,5 @@
 import { Image, StyleSheet, Text, View } from "react-native";
-
-type Place = {
-  id: string;
-  name: string;
-  image: any;
-  district: string;
-  date: string;
-  category: string;
-};
+import type { Place } from "../types/passport.types";
 
 type SearchPassportCardProps = {
   item: Place;

--- a/src/features/search/components/PassportFrame.tsx
+++ b/src/features/search/components/PassportFrame.tsx
@@ -1,7 +1,233 @@
-import { Text } from "react-native"
+import { Image, StyleSheet, Text, View } from "react-native";
 
-export default function PassportFrame() {
+type Place = {
+  id: string;
+  name: string;
+  image: any;
+  district: string;
+  date: string;
+  category: string;
+};
+
+type SearchPassportCardProps = {
+  item: Place;
+};
+
+export default function PassportFrame({item}: SearchPassportCardProps) {
   return (
-    <Text>여권 목록 받아오기</Text>
+    <View style={styles.passportCard}>
+      <Image
+        source={require("@/assets/images/noise.png")}
+        style={styles.noiseBackground}
+        resizeMode="cover"
+      />
+
+      <View style={styles.passportContent}>
+        {/*여권 위쪽 부분*/}
+        <View style={styles.topHalf}>
+          <Image 
+            source={require("@/assets/images/pinktape.png")}
+            style={styles.tape}
+            resizeMode="contain"
+          />
+          <Image 
+            source={item.image}
+            style={styles.placeImage}
+            resizeMode="cover"
+          />
+          <Image 
+            source={require("@/assets/images/StampSeal.png")}
+            style={styles.stampImage}
+            resizeMode="contain"
+          />
+
+          <View style={styles.infoArea}>
+            <Text style={styles.infoRow}>📍 {item.name}</Text>
+            <Text style={styles.infoRow}>🗓 {item.date}</Text>
+          </View>
+        </View>
+
+        {/*구분선*/}
+        <View style={styles.dividerRow}>
+          <View style={styles.dividerCircleLeft} />
+          <View style={styles.dividerLine} />
+          <View style={styles.dividerCircleRight} />
+        </View>
+
+        {/*여권 아래쪽 부분*/}
+        <View style={styles.bottomHalf}>
+          <View style={styles.reviewBox}>
+            <Text style={styles.reviewText}>
+              "마포구에서 맛있는 커피를 파는 카페를 찾았다! 케이크도 있었는데 다음에 가면 케이크도 꼭 먹어 봐야겠다는 생각이 들었다. 🍰"
+            </Text>
+          </View>
+
+          <View style={styles.musicBox}>
+            <Image 
+              source={require("@/assets/images/profile1.jpg")}
+              style={styles.musicImage}
+            />
+
+            <View style={styles.musicText}>
+              <Text style={styles.musicTitle}>멍냥</Text>
+              <Text style={styles.musicArtist}>KiiiKiii</Text>
+            </View>
+          </View>
+
+          <Text style={styles.scrollText}>
+            {`<<<<<<<<<<<<<< scroll down >>>>>>>>>>>>>>`}
+          </Text>
+        </View>
+      </View>
+    </View>
   )
 }
+
+const styles = StyleSheet.create({
+  passportCard: {
+    flex: 1,
+    width: "100%",
+    position: "relative",
+    backgroundColor: "#F8FAFD",
+    borderRadius: 16,
+    overflow: "hidden",
+  },
+  noiseBackground: {
+    position: "absolute",
+    width: "100%",
+    height: "100%",
+    opacity: 1,
+  },
+  passportContent: {
+    flex: 1,
+    position: "relative",
+    zIndex: 1,
+  },
+  topHalf: {
+    flex: 1.05,
+    position: "relative",
+    paddingTop: 28,
+  },
+  tape: {
+    position: "absolute",
+    top: 28,
+    left: "40%",
+    width: 70,
+    height: 50,
+    zIndex: 10,
+    transform: [{rotate: "5deg"}],
+  },
+  placeImage: {
+    position: "absolute",
+    left: 28,
+    top: 45,
+    width: 150,
+    height: 150,
+    transform: [{rotate: "-7deg"}], 
+    borderWidth: 8,
+    borderColor: "#FFFFFF",
+  },
+  stampImage: {
+    position: "absolute",
+    right: 5,
+    top: 55,
+    width: 120,
+    height: 120,
+  },
+  infoArea: {
+    position: "absolute",
+    right: 24,
+    bottom: 28,
+    gap: 8,
+  },
+  infoRow: {
+    fontSize: 12,
+    color: "#222222",
+    fontWeight: "600",
+    fontFamily: 'Griun_Gellyroll',
+  },
+  dividerRow: {
+    height: 15,
+    flexDirection: "row",
+    alignItems: "center",
+    position: "relative",
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    borderWidth: 0.5,
+    borderColor: "#C8C8C8",
+  },
+  dividerCircleLeft: {
+    position: "absolute",
+    left: -11,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: "#F8FAFD",
+    zIndex: 2,
+  },
+  dividerCircleRight: {
+    position: "absolute",
+    right: -11,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: "#F8FAFD",
+    zIndex: 2,
+  },
+  bottomHalf: {
+    flex: 0.95,
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 12,
+  },
+  reviewBox: {
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 18,
+  },
+  reviewText: {
+    fontSize: 13,
+    lineHeight: 22,
+    color: "#111111",
+    textAlign: "center",
+    fontWeight: "500",
+    fontFamily: 'Griun_Gellyroll',
+  },
+  musicBox: {
+    height: 68,
+    backgroundColor: "#FFFFFF",
+    borderRadius: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 18,
+    gap: 14,
+    marginBottom: 12,
+  },
+  musicImage: {
+    width: 46,
+    height: 46,
+    borderRadius: 23,
+    marginRight: 65,
+  },
+  musicText: {
+    alignItems: "center",
+  },
+  musicTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#111111",
+  },
+  musicArtist: {
+    fontSize: 12,
+    color: "#111111",
+    marginTop: 4,
+  },
+  scrollText: {
+    fontSize: 13,
+    color: "#333333",
+    textAlign: "center",
+    fontFamily: 'SpaceMono',
+  }
+})

--- a/src/features/search/components/SearchUserCard.tsx
+++ b/src/features/search/components/SearchUserCard.tsx
@@ -1,0 +1,88 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { searchUserDummy } from "../data/searchDummy";
+
+type SearchUserCardProps = {
+    onAddFriend: () => void;
+};
+
+export default function SearchUserCard({onAddFriend}: SearchUserCardProps) {
+    return(
+        <View style={styles.userInfoBox}>
+        <View style={styles.userRow}>
+            <Image
+                source={require("@/assets/images/profile1.jpg")}
+                style={styles.profileImage}
+            />
+            
+            <View style={styles.userTextArea}>
+                <View style={styles.nameRow}>
+                    <Text style={styles.userName}>{searchUserDummy.name}</Text>
+                    <Text style={styles.userId}>#{searchUserDummy.id}</Text>
+                </View>
+            
+                <View style={styles.locationRow}>
+                    <Ionicons name="location-outline" size={12} color="#666667" />
+                    <Text style={styles.locationText}>{searchUserDummy.location}</Text>
+                </View>
+            </View>
+            
+            <TouchableOpacity style={styles.addButton} onPress={onAddFriend}>
+                <Ionicons name="person-add-outline" size={20} color="#000000" />
+            </TouchableOpacity>
+        </View>
+    </View>
+    )
+}
+
+const styles=StyleSheet.create({
+    userInfoBox: {
+        paddingLeft: 22,
+        paddingRight: 22,
+        paddingTop: 22,
+    },
+    userRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        marginBottom: 22,
+    },
+    profileImage: {
+        height: 48,
+        width: 48,
+        borderRadius: 24,
+    },
+    userTextArea: {
+        flex: 1,
+        marginLeft: 12,
+    },
+    nameRow: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    userName: {
+        fontSize: 20,
+        fontWeight: "700",
+        color: "#000000",
+    },
+    userId: {
+        marginLeft: 5,
+        fontSize: 14,
+        color: "#666667",
+        fontWeight: "500",
+        marginTop: 5,
+    },
+    locationRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        marginTop: 4,
+    },
+    locationText: {
+        marginLeft: 2,
+        fontSize: 10,
+        color: "#666667",
+    },
+    addButton: {
+        marginTop: 35,
+        marginRight: -5,
+    },
+})

--- a/src/features/search/data/passportDummy.ts
+++ b/src/features/search/data/passportDummy.ts
@@ -1,0 +1,53 @@
+import type { Place } from "../types/passport.types"
+
+// 임시 더미 데이터
+export const passportDummy: Place[] = [
+    {
+        id: "1",
+        name: "렉터스라운지 홍대",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "마포구",
+        date: "2026-03-30",
+        category: "카페",
+    },
+    {
+        id: "2",
+        name: "다운타우너",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "용산구",
+        date: "2026-03-16",
+        category: "식당",
+    },
+    {
+        id: "3",
+        name: "포셋 연희",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "서대문구",
+        date: "2026-02-24",
+        category: "카페",
+    },
+    {
+        id: "4",
+        name: "명동 쇼핑 거리",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "중구",
+        date: "2026-04-12",
+        category: "쇼핑",
+    },
+    {
+        id: "5",
+        name: "초이다이닝 강남",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "강남구",
+        date: "2026-01-30",
+        category: "음식점",
+    },
+    {
+        id: "6",
+        name: "카페 드 파리",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "서초구",
+        date: "2026-02-15",
+        category: "카페",
+    },
+]

--- a/src/features/search/screens/searchScreen.tsx
+++ b/src/features/search/screens/searchScreen.tsx
@@ -7,23 +7,17 @@ import {
     ScrollView,
     StyleSheet,
     Text,
-    TouchableOpacity,
     View
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import PassportActionButtons from "../components/PassportActionButtons";
 import PassportFrame from "../components/PassportFrame";
 import SearchToggle from "../components/SearchToggle";
-import { rankingDummy, searchUserDummy } from "../data/searchDummy";
-import { RankingUser, SearchTab } from "../types/search.types";
+import SearchUserCard from "../components/SearchUserCard";
 
-type Place = {
-    id: string;
-    name: string;
-    image: any;
-    district: string;
-    date: string;
-    category: string;
-}
+import { passportDummy } from "../data/passportDummy";
+import { rankingDummy } from "../data/searchDummy";
+import { RankingUser, SearchTab } from "../types/search.types";
 
 export default function SearchView() {
 
@@ -57,61 +51,7 @@ export default function SearchView() {
     )
 }
 
-{/*둘러보기 메인 화면*/}
-const {height} = Dimensions.get("window");
-
-// 임시 더미 데이터
-const passportDummy: Place[] = [
-    {
-        id: "1",
-        name: "렉터스라운지 홍대",
-        image: require("@/assets/images/profile1.jpg"),
-        district: "마포구",
-        date: "2026-03-30",
-        category: "카페",
-    },
-    {
-        id: "2",
-        name: "다운타우너",
-        image: require("@/assets/images/profile2.jpg"),
-        district: "용산구",
-        date: "2026-03-16",
-        category: "식당",
-    },
-    {
-        id: "3",
-        name: "포셋 연희",
-        image: require("@/assets/images/profile1.jpg"),
-        district: "서대문구",
-        date: "2026-02-24",
-        category: "카페",
-    },
-    {
-        id: "4",
-        name: "명동 쇼핑 거리",
-        image: require("@/assets/images/profile2.jpg"),
-        district: "중구",
-        date: "2026-04-12",
-        category: "쇼핑",
-    },
-    {
-        id: "5",
-        name: "초이다이닝 강남",
-        image: require("@/assets/images/profile1.jpg"),
-        district: "강남구",
-        date: "2026-01-30",
-        category: "음식점",
-    },
-    {
-        id: "6",
-        name: "카페 드 파리",
-        image: require("@/assets/images/profile2.jpg"),
-        district: "서초구",
-        date: "2026-02-15",
-        category: "카페",
-    },
-]
-
+/*둘러보기 메인 화면*/
 function AllSearchContent() {
 
     // 친구 추가 메시지
@@ -153,7 +93,7 @@ function AllSearchContent() {
                 renderItem= {({item}) => (
                     <View style={styles.reelsPage}>
                         <View style={styles.card}>
-                            <Image 
+                        <Image 
                                 source={require("@/assets/images/noise.png")}
                                 style={styles.noiseBackground}
                                 resizeMode="cover"
@@ -161,56 +101,22 @@ function AllSearchContent() {
 
                             <View style={styles.cardContent}>
                                 {/*사용자 정보*/}
-                                <View style={styles.userInfoBox}>
-                                    <View style={styles.userRow}>
-                                        <Image
-                                            source={require("@/assets/images/profile1.jpg")}
-                                            style={styles.profileImage}
-                                        />
+                                <SearchUserCard onAddFriend={handleAddFriend} />
+                            
+                                {/*여권 상세*/}
+                                <View style={styles.passportDetailArea}>
+                                    <PassportFrame item={item} />
 
-                                        <View style={styles.userTextArea}>
-                                            <View style={styles.nameRow}>
-                                                <Text style={styles.userName}>{searchUserDummy.name}</Text>
-                                                <Text style={styles.userId}>#{searchUserDummy.id}</Text>
-                                            </View>
-
-                                        <View style={styles.locationRow}>
-                                            <Ionicons name="location-outline" size={12} color="#666667" />
-                                            <Text style={styles.locationText}>{searchUserDummy.location}</Text>
-                                        </View>
-                                    </View>
-
-                                    <TouchableOpacity style={styles.addButton} onPress={handleAddFriend}>
-                                        <Ionicons name="person-add-outline" size={20} color="#000000" />
-                                    </TouchableOpacity>
-                                </View>
-                            </View>
-
-                            {/*여권 상세*/}
-                            <View style={styles.passportDetailArea}>
-                                <PassportFrame item={item} />
-
-                                <View style={styles.actionButtonArea}>
-                                    <TouchableOpacity onPress={() => toggleLike(item.id)}>
-                                        <Ionicons 
-                                            name={likeIds.includes(item.id) ? "heart" : "heart-outline"}
-                                            size={24}
-                                            color={likeIds.includes(item.id) ? "#ED3838" : "#333333"}
-                                        />
-                                    </TouchableOpacity>
-
-                                    <TouchableOpacity onPress={() => toggleScrap(item.id)}>
-                                        <Ionicons 
-                                            name={scrappedIds.includes(item.id) ? "bookmark" : "bookmark-outline"}
-                                            size={24}
-                                            color={scrappedIds.includes(item.id) ? "#FFD233" : "#333333"}
-                                        />
-                                    </TouchableOpacity>
+                                    <PassportActionButtons
+                                        isLiked={likeIds.includes(item.id)}
+                                        isScrapped={scrappedIds.includes(item.id)}
+                                        onPressLike={() => toggleLike(item.id)}
+                                        onPressScrap={() => toggleScrap(item.id)}
+                                    />
                                 </View>
                             </View>
                         </View>
                     </View>
-                </View>
             )}
             pagingEnabled
             showsVerticalScrollIndicator={false}
@@ -226,7 +132,7 @@ function AllSearchContent() {
     );
 }
 
-{/*랭킹 메인화면*/}
+/*랭킹 메인화면*/
 function RankingContent() {
 
     const topThree = rankingDummy.slice(0, 3);
@@ -249,7 +155,7 @@ function RankingContent() {
     )
 }
 
-{/*랭킹 Top3*/}
+/*랭킹 Top3*/
 function TopRankingCard({user}: {user: RankingUser}) {
     return(
         <View style={styles.topRankingCard}>
@@ -264,7 +170,7 @@ function TopRankingCard({user}: {user: RankingUser}) {
     )
 }
 
-{/*나머지 리스트*/}
+/*나머지 리스트*/
 function RankingItem({user}: {user: RankingUser}) {
     return(
         <View style={styles.rankingItem}>
@@ -297,7 +203,7 @@ function RankingItem({user}: {user: RankingUser}) {
     )
 }
 
-{/*메달 얻는 함수*/}
+/*메달 얻는 함수*/
 function getMedal(rank: number) {
     if (rank === 1) return "🥇";
     if (rank === 2) return "🥈";
@@ -305,7 +211,7 @@ function getMedal(rank: number) {
     return "";
 }
 
-{/*트로피 얻는 함수*/}
+/*트로피 얻는 함수*/
 function getTrophy(rank: number) {
     if (rank === 1) return "🏆";
     if (rank === 2) return "🏆";
@@ -313,7 +219,7 @@ function getTrophy(rank: number) {
     return "";
 }
 
-{/*등수별 트로피 배경 색 얻는 함수*/}
+/*등수별 트로피 배경 색 얻는 함수*/
 function getTrophyBackgroundColor(rank: number) {
     if (rank === 1) return "#FFD700"; 
     if (rank === 2) return "#C0C0C0";
@@ -383,6 +289,11 @@ const styles = StyleSheet.create({
         elevation: 5,
         overflow: "hidden",
     },
+    cardContent: {
+        flex: 1,
+        position: "relative",
+        zIndex: 1,
+    },
     noiseBackground: {
         position: "absolute",
         top: 0,
@@ -391,67 +302,6 @@ const styles = StyleSheet.create({
         left: 0,
         opacity: 1,
         zIndex: 0,
-    },
-    actionButtonArea: {
-        position: "absolute",
-        top: 16,
-        right: 14,
-        zIndex: 20,
-        gap: 10,
-    },
-    userInfoBox: {
-        paddingLeft: 22,
-        paddingRight: 22,
-        paddingTop: 22,
-    },
-    cardContent: {
-        flex: 1,
-        position: "relative",
-        zIndex: 1,
-    },
-    userRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        marginBottom: 22,
-    },
-    profileImage: {
-        height: 48,
-        width: 48,
-        borderRadius: 24,
-    },
-    userTextArea: {
-        flex: 1,
-        marginLeft: 12,
-    },
-    nameRow: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    userName: {
-        fontSize: 20,
-        fontWeight: "700",
-        color: "#000000",
-    },
-    userId: {
-        marginLeft: 5,
-        fontSize: 14,
-        color: "#666667",
-        fontWeight: "500",
-        marginTop: 5,
-    },
-    locationRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        marginTop: 4,
-    },
-    locationText: {
-        marginLeft: 2,
-        fontSize: 10,
-        color: "#666667",
-    },
-    addButton: {
-        marginTop: 35,
-        marginRight: -5,
     },
     addMessageBox: {
         position: "absolute",

--- a/src/features/search/screens/searchScreen.tsx
+++ b/src/features/search/screens/searchScreen.tsx
@@ -1,6 +1,8 @@
 import { Ionicons } from "@expo/vector-icons";
 import { useState } from "react";
 import {
+    Dimensions,
+    FlatList,
     Image,
     ScrollView,
     StyleSheet,
@@ -14,16 +16,21 @@ import SearchToggle from "../components/SearchToggle";
 import { rankingDummy, searchUserDummy } from "../data/searchDummy";
 import { RankingUser, SearchTab } from "../types/search.types";
 
+type Place = {
+    id: string;
+    name: string;
+    image: any;
+    district: string;
+    date: string;
+    category: string;
+}
+
 export default function SearchView() {
 
     const [selectedTab, setSelectedTab] = useState<SearchTab>("all")
 
     return(
         <SafeAreaView style={styles.container}>
-            <ScrollView
-                contentContainerStyle={styles.scrollContent}
-                showsVerticalScrollIndicator={false}
-            >
                 {/*헤더*/}
                 <View style={styles.header}>
                     <Text style={styles.title}>
@@ -39,51 +46,184 @@ export default function SearchView() {
                 {selectedTab === "all" ? (
                     <AllSearchContent />
                 ) : (
-                    <RankingContent />
+                    <ScrollView 
+                        contentContainerStyle={styles.scrollContent}
+                        showsVerticalScrollIndicator={false}
+                    >
+                        <RankingContent />
+                    </ScrollView>
                 )}         
-            </ScrollView>
         </SafeAreaView>   
     )
 }
 
 {/*둘러보기 메인 화면*/}
+const {height} = Dimensions.get("window");
+
+// 임시 더미 데이터
+const passportDummy: Place[] = [
+    {
+        id: "1",
+        name: "렉터스라운지 홍대",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "마포구",
+        date: "2026-03-30",
+        category: "카페",
+    },
+    {
+        id: "2",
+        name: "다운타우너",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "용산구",
+        date: "2026-03-16",
+        category: "식당",
+    },
+    {
+        id: "3",
+        name: "포셋 연희",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "서대문구",
+        date: "2026-02-24",
+        category: "카페",
+    },
+    {
+        id: "4",
+        name: "명동 쇼핑 거리",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "중구",
+        date: "2026-04-12",
+        category: "쇼핑",
+    },
+    {
+        id: "5",
+        name: "초이다이닝 강남",
+        image: require("@/assets/images/profile1.jpg"),
+        district: "강남구",
+        date: "2026-01-30",
+        category: "음식점",
+    },
+    {
+        id: "6",
+        name: "카페 드 파리",
+        image: require("@/assets/images/profile2.jpg"),
+        district: "서초구",
+        date: "2026-02-15",
+        category: "카페",
+    },
+]
+
 function AllSearchContent() {
+
+    // 친구 추가 메시지
+    const [showAddMessage, setShowAddMessage] = useState(false);
+
+    const handleAddFriend = () => {
+        setShowAddMessage(true);
+
+        setTimeout(() => {
+            setShowAddMessage(false);
+        }, 2000);
+    };
+
+    // 좋아요 및 스크랩
+    const [likeIds, setLikeIds] = useState<string[]>([]);
+    const [scrappedIds, setScrapped] = useState<string[]>([]);
+
+    const toggleLike = (id: string) => {
+        setLikeIds((prev) =>
+            prev.includes(id)
+                ? prev.filter((likeId) => likeId !== id)
+                : [...prev, id]
+        );
+    };
+
+    const toggleScrap = (id: string) => {
+        setScrapped((prev) => 
+            prev.includes(id)
+                ? prev.filter((scrappedId) => scrappedId !== id)
+                : [...prev, id]
+        );
+    };
+
     return(
-        <View style={styles.card}>
-            <Image 
-                source={require("@/assets/images/noise.png")}
-                style={styles.noiseBackground}
-                resizeMode="cover"
-            />
+        <View style={styles.reelsContainer}>
+            <FlatList
+                data={passportDummy}
+                keyExtractor= {(item) => item.id}
+                renderItem= {({item}) => (
+                    <View style={styles.reelsPage}>
+                        <View style={styles.card}>
+                            <Image 
+                                source={require("@/assets/images/noise.png")}
+                                style={styles.noiseBackground}
+                                resizeMode="cover"
+                            />
 
-            <View style={styles.cardContent}>
-                <View style={styles.userRow}>
-                    <Image
-                        source={require("@/assets/images/profile1.jpg")}
-                        style={styles.profileImage}
-                    />
+                            <View style={styles.cardContent}>
+                                {/*사용자 정보*/}
+                                <View style={styles.userInfoBox}>
+                                    <View style={styles.userRow}>
+                                        <Image
+                                            source={require("@/assets/images/profile1.jpg")}
+                                            style={styles.profileImage}
+                                        />
 
-                    <View style={styles.userTextArea}>
-                        <View style={styles.nameRow}>
-                            <Text style={styles.userName}>{searchUserDummy.name}</Text>
-                            <Text style={styles.userId}>#{searchUserDummy.id}</Text>
-                        </View>
+                                        <View style={styles.userTextArea}>
+                                            <View style={styles.nameRow}>
+                                                <Text style={styles.userName}>{searchUserDummy.name}</Text>
+                                                <Text style={styles.userId}>#{searchUserDummy.id}</Text>
+                                            </View>
 
-                        <View style={styles.locationRow}>
-                            <Ionicons name="location-outline" size={12} color="#666667" />
-                            <Text style={styles.locationText}>{searchUserDummy.location}</Text>
+                                        <View style={styles.locationRow}>
+                                            <Ionicons name="location-outline" size={12} color="#666667" />
+                                            <Text style={styles.locationText}>{searchUserDummy.location}</Text>
+                                        </View>
+                                    </View>
+
+                                    <TouchableOpacity style={styles.addButton} onPress={handleAddFriend}>
+                                        <Ionicons name="person-add-outline" size={20} color="#000000" />
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
+
+                            {/*여권 상세*/}
+                            <View style={styles.passportDetailArea}>
+                                <PassportFrame item={item} />
+
+                                <View style={styles.actionButtonArea}>
+                                    <TouchableOpacity onPress={() => toggleLike(item.id)}>
+                                        <Ionicons 
+                                            name={likeIds.includes(item.id) ? "heart" : "heart-outline"}
+                                            size={24}
+                                            color={likeIds.includes(item.id) ? "#ED3838" : "#333333"}
+                                        />
+                                    </TouchableOpacity>
+
+                                    <TouchableOpacity onPress={() => toggleScrap(item.id)}>
+                                        <Ionicons 
+                                            name={scrappedIds.includes(item.id) ? "bookmark" : "bookmark-outline"}
+                                            size={24}
+                                            color={scrappedIds.includes(item.id) ? "#FFD233" : "#333333"}
+                                        />
+                                    </TouchableOpacity>
+                                </View>
+                            </View>
                         </View>
                     </View>
-
-                    <TouchableOpacity style={styles.addButton}>
-                        <Ionicons name="person-add-outline" size={20} color="#000000" />
-                    </TouchableOpacity>
                 </View>
-                
-                <PassportFrame />
+            )}
+            pagingEnabled
+            showsVerticalScrollIndicator={false}
+            decelerationRate="fast"
+        /> 
+
+        {showAddMessage && (
+            <View style={styles.addMessageBox}>
+                <Text style={styles.addMessageText}>친구 추가 요청을 보냈습니다.</Text>
             </View>
-        </View>
-    )
+        )}
+    </View>
+    );
 }
 
 {/*랭킹 메인화면*/}
@@ -182,6 +322,33 @@ function getTrophyBackgroundColor(rank: number) {
 
 const styles = StyleSheet.create({
     // 둘러보기
+    reelsContainer: {
+        flex: 1,
+        position: "relative",
+    },
+    reelsPage: {
+        height: Dimensions.get("window").height - 150,
+        paddingHorizontal: 20,
+        paddingBottom: 24,
+    },
+    passportDetailArea: {
+        flex: 1,
+        position: "relative",
+        width: "100%",
+        marginTop: -8,
+        borderRadius: 16,
+        overflow: "hidden",
+
+        shadowColor: "#000000",
+        shadowOffset: {
+            width: 0,
+            height: -2,
+        },
+        shadowOpacity: 0.14,
+        shadowRadius: 5,
+        elevation: 6,
+        zIndex: 10,
+    },
     container: {
         flex: 1,
         backgroundColor: "#F8FAFD",
@@ -196,6 +363,8 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "space-between",
         marginBottom: 20,
+        paddingHorizontal: 20,
+        paddingTop: 22,
     },
     title: {
         fontWeight: "700",
@@ -203,12 +372,13 @@ const styles = StyleSheet.create({
         fontSize: 24
     },
     card: {
+        flex: 1,
         position: "relative",
+        width: "100%",
         backgroundColor: "#F8FAFD",
         borderRadius: 16,
-        padding: 22,
         shadowColor: "#000000",
-        shadowOpacity: 0.13,
+        shadowOpacity: 0.3,
         shadowRadius: 6,
         elevation: 5,
         overflow: "hidden",
@@ -222,7 +392,20 @@ const styles = StyleSheet.create({
         opacity: 1,
         zIndex: 0,
     },
+    actionButtonArea: {
+        position: "absolute",
+        top: 16,
+        right: 14,
+        zIndex: 20,
+        gap: 10,
+    },
+    userInfoBox: {
+        paddingLeft: 22,
+        paddingRight: 22,
+        paddingTop: 22,
+    },
     cardContent: {
+        flex: 1,
         position: "relative",
         zIndex: 1,
     },
@@ -268,6 +451,22 @@ const styles = StyleSheet.create({
     },
     addButton: {
         marginTop: 35,
+        marginRight: -5,
+    },
+    addMessageBox: {
+        position: "absolute",
+        left: 40,
+        right: 40,
+        top: "45%",
+        backgroundColor: "#1A3A6B",
+        borderRadius: 12,
+        paddingVertical: 12,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    addMessageText: {
+        color: "#FFFFFF",
+        fontSize: 14,
     },
 
     // 랭킹

--- a/src/features/search/types/passport.types.ts
+++ b/src/features/search/types/passport.types.ts
@@ -1,0 +1,8 @@
+export type Place = {
+    id: string;
+    name: string;
+    image: any;
+    district: string;
+    date: string;
+    category: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #21 

## 📝 작업 내용
#### 1. 릴스 기능 UI 구현
둘러보기 화면은 FlatList와 pagingEnabled를 사용해 여권 상세 카드가 세로로 한 장씩 넘어가도록 함. 여권 카드는 PassportDetail 파일의 내용을 직접 사용하지 않고, 둘러보기 전용 컴포넌트 PassportFrame을 새로 만들어 필요한 여권 내용만 표시하도록 함.

#### 2. 친구 추가 기능 연결
친구 추가 아이콘 클릭 시 showAddMessage 상태를 사용해서 안내 메시지를 띄움.

#### 3. 좋아요 및 스크랩 state로 보여주기
useState로 선택된 여권 id 목록을 관리하여, 누르면 아이콘이 각각 빨간색 하트/노란색 북마크로 변경되도록 함.


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

