### PR TITLE
feat: 내 프로필 조회 API 연결

### DIFF
--- a/src/features/profile/data/profileDummy.ts
+++ b/src/features/profile/data/profileDummy.ts
@@ -7,7 +7,7 @@ export const profileUserDummy: ProfileUser = {
     lightCount: 12,
     locationCount: 23,
     totallike: 320,
-    profileImage: require("@/assets/images/favicon.png")
+    profileImage: null,
 };
 
 export const settingMenuDummy: ProfileMenuItem[] = [

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,7 +1,10 @@
+import { BASE_URL } from "@/src/api/config";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import * as Securestore from "expo-secure-store";
+import { useEffect, useState } from "react";
 import {
+    ActivityIndicator,
     Image,
     ScrollView,
     StyleSheet,
@@ -14,12 +17,87 @@ import {
     profileUserDummy,
     settingMenuDummy
 } from "../data/profileDummy";
+import { ProfileUser } from "../types/profile.types";
+
+type MyProfileResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: {
+        userId: number;
+        nickname: string;
+        email: string;
+        profileImg: string | null;
+        friendCode: string;
+        location: string | null;
+        bio: string | null;
+        currentMode: string;
+        createdAt: string;
+        stats: {
+            districtCount: number;
+            passportCount: number;
+            likeCount: number;
+        }
+    }
+}
 
 export default function ProfileView() {
     const router = useRouter();
-    const [isTeam, setIsTeam] = useState(false);
 
-    const user = profileUserDummy;
+    const [isTeam, setIsTeam] = useState(false);
+    const [user, setUser] = useState<ProfileUser>(profileUserDummy);
+    const [isLoading, setIsLoading] = useState(true);
+
+    // 1. 내 프로필 조회 API 연결
+    useEffect(() => {
+        const fetchMyProfile = async () => {
+            const accessToken = await Securestore.getItemAsync("accessToken");
+            try {
+                const response = await fetch(`${BASE_URL}/api/v1/users/me`, {
+                    method: "GET",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${accessToken}`,
+                    }
+                });
+
+                const result: MyProfileResponse = await response.json();
+
+                console.log("내 프로필 조회 상태 코드:", response.status);
+                console.log("내 프로필 조회 응답:", result);
+
+                if (!response.ok || !result.success) {
+                    throw new Error(result.message || "내 프로필 조회 실패")
+                }
+
+                const profileData = result.data;
+
+                setUser({
+                    id: `#${profileData.userId}`,
+                    name: profileData.nickname,
+                    location: profileData.location || "위치 미설정",
+                    passportCount: profileData.stats.passportCount ?? 0,
+                    districtCount: profileData.stats.districtCount ?? 0,
+                    totallike: profileData.stats.likeCount ?? 0,
+                    profileImage: profileData.profileImg,
+                });
+            } catch(error) {
+                console.log("내 프로필 조회 에러:", error);
+            } finally {
+                setIsLoading(false);
+            }
+        }
+
+        fetchMyProfile();
+    }, []);
+
+    if (isLoading) {
+        return(
+            <View style={styles.loadingContainer}>
+                <ActivityIndicator size="large" color="#1A3A6B" />
+            </View>
+        )
+    }
 
     return(
         <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -28,7 +106,14 @@ export default function ProfileView() {
             {/*프로필 카드*/}
             <View style={styles.profileCard}>
                 <View style={styles.profileLeft}>
-                    <Image source={user.profileImage} style={styles.profileImage} />
+                    <Image 
+                        source={
+                            user.profileImage
+                                ? {uri: user.profileImage}
+                                : require("@/assets/images/favicon.png")
+                        } 
+                        style={styles.profileImage} 
+                    />
                     <View>
                         <Text style={styles.userName}>{user.name}</Text>
                         <View style={styles.locationSection}>
@@ -36,7 +121,7 @@ export default function ProfileView() {
                             <Text style={styles.userLocation}>{user.location}</Text>
                         </View>
                         <Text style={styles.userStatus}>
-                            {user.lightCount} | {user.locationCount} | {user.totallike}
+                            불빛: {user.passportCount} | 장소: {user.districtCount} | 좋아요: {user.totallike}
                         </Text>
                     </View>
                 </View>
@@ -107,7 +192,7 @@ export default function ProfileView() {
                         >
                             <View style={styles.menuLeft}>
                                 <View style={styles.iconBox}>
-                                <   Ionicons name={item.icon as any} size={22} color="#FFFFFF" />
+                                <Ionicons name={item.icon as any} size={22} color="#FFFFFF" />
                                 </View>
 
                                 <View>
@@ -231,6 +316,12 @@ const styles = StyleSheet.create({
         color: "#FFFFFF",
         fontSize: 14,
         marginTop: 8,
+    },
+    loadingContainer: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "#F8FAFD",
     },
 
     /*프리미엄*/

--- a/src/features/profile/types/profile.types.ts
+++ b/src/features/profile/types/profile.types.ts
@@ -1,13 +1,11 @@
-import { ImageSourcePropType } from "react-native";
-
 export type ProfileUser = {
     id: string;
     name: string;
     location: string;
-    lightCount: number;
+    districtCount: number;
     locationCount: number;
     totallike: number;
-    profileImage: ImageSourcePropType;
+    profileImage: string | null;
 };
 
 export type ProfileMenuItem = {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #46 

## 📝 작업 내용
- **<방식>**
    - `profileScreen.tsx`에서 화면 진입 시 `useEffect`를 사용해 `/api/v1/users/me` API를 호출한다.
    - API 응답으로 받은 `nickname`, `location`, `friendCode`, `profileImg`, `stats` 값을 화면에서 사용하는 `ProfileUser` 타입에 맞게 변환한다.
    - `stats.passportCount`는 전체 기록 수, `stats.districtCount`는 방문한 지역 수, `stats.likeCount`는 총 좋아요 수로 매핑한다.
- **<화면 흐름>**
    - 사용자가 마이페이지 탭에 진입하면 `ProfileView`가 렌더링된다.
    - 화면 진입과 동시에 내 프로필 조회 API가 실행된다.
    - API 호출에 성공하면 응답 데이터를 `setUser`로 저장하고, 프로필 카드에 사용자 정보가 반영된다.
    - 프로필 카드에는 이름, 위치, 방문한 지역 수, 기록 수, 총 좋아요 수, 사용자 고유번호, 프로필 이미지가 표시된다.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

