### PR TITLE
feat: 친구 추가 API 연결

### DIFF
--- a/src/features/profile/data/profileDummy.ts
+++ b/src/features/profile/data/profileDummy.ts
@@ -4,8 +4,8 @@ export const profileUserDummy: ProfileUser = {
     id: "#30421",
     name: "저희이제하조",
     location: "고양시 덕양구",
-    lightCount: 12,
-    locationCount: 23,
+    passportCount: 12,
+    districtCount: 23,
     totallike: 320,
     profileImage: null,
 };

--- a/src/features/profile/types/profile.types.ts
+++ b/src/features/profile/types/profile.types.ts
@@ -2,9 +2,9 @@ export type ProfileUser = {
     id: string;
     name: string;
     location: string;
-    districtCount: number;
-    locationCount: number;
-    totallike: number;
+    districtCount: number; // 방문한 지역 수
+    passportCount: number; // 기록 수
+    totallike: number; // 좋아요 수
     profileImage: string | null;
 };
 

--- a/src/features/social/components/AddFriendModal.tsx
+++ b/src/features/social/components/AddFriendModal.tsx
@@ -145,11 +145,52 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
     }
 
     // 3. 친구 추가하는 API 연결
-    const handleAddFriend = (friend: RecommendedFriend) => {
-        Alert.alert(
-            "친구 요청 완료!",
-            `${friend.nickname}님에게 친구 요청을 보냈습니다.\n관련 정보는 마이페이지에서 확인할 수 있습니다.`
-        );
+    const handleAddFriend = async (friend: RecommendedFriend) => {
+        const accessToken = await Securestore.getItemAsync("accessToken");
+
+        try {
+            const requestUrl = `${BASE_URL}/api/v1/friends/request`;
+
+            console.log("친구 요청 시작");
+            console.log("친구 요청 URL:", requestUrl)
+            console.log("보낼 친구 코드:", friend.friendCode);
+
+            const response = await fetch(requestUrl, {
+                method: "POST",
+                headers: {
+                    "Contetnt-Type": "application/json",
+                    Authorization: `Bearer ${accessToken}`,
+                },
+                body: JSON.stringify({
+                    friendCode: friend.friendCode,
+                })
+            })
+
+            const data = await response.json();
+
+            console.log("친구 요청 응답 상태:", response.status);
+            console.log("친구 요청 응답 데이터:", data);
+
+            if(!response.ok || !data.success) {
+                throw new Error(data.message || "친구 요청에 실패했습니다.")
+            }
+
+            Alert.alert(
+                "친구 요청 완료!",
+                `${friend.nickname}님에게 친구 요청을 보냈습니다.`
+            );
+
+            // 친구 요청 성공 후 추천 친구 목록 다시 불러오기
+            fetchRecommendedFriends();
+        } catch(error) {
+            console.log("친구 요청 에러:", error)
+
+            if(error instanceof Error) {
+                Alert.alert("친구 요청 실패", error.message)
+            }else {
+                Alert.alert("친구 요청 실패", "알 수 없는 오류가 발생했습니다.")
+            }
+        }
     };
 
     return (

--- a/src/features/social/types/social.types.ts
+++ b/src/features/social/types/social.types.ts
@@ -11,7 +11,7 @@ export type Friend = {
     friendId: number; // 친구 아이디 번호
     userId: number // 사용자 아이디 번호
     name: string; // 사용자 닉네임
-    profileImg: string | null; //프로필 이미지지
+    profileImg: string | null; //프로필 이미지
     friendCode: string; // 친구 코드
     status: string;
     createdAt: string;
@@ -33,7 +33,7 @@ export type RecommendedFriend = {
     status: string;
     createdAt: string;
 
-    stampCount: number; // 도장 개수
+    stampCount?: number; // 도장 개수
     mutualFriends?: MutualFriend[]; // 함께 아는 친구
     image?: ImageSourcePropType; // 사진
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #43 

## 📝 작업 내용
친구 추가 API를 연결하였습니다. (`POST/api/v1/friends/request`)
**<방식>**
- 친구 추가 바텀시트인 `AddFriendModal.tsx`에서 추천 친구 목록 조회, 친구 코드 검색, 친구 요청 API를 처리하도록 구성
- `추가` 버튼을 누르면 `POST /api/v1/friends/request`를 호출
- 요청 body에는 Swagger 형식에 맞게 `{ friendCode: friend.friendCode }`를 전달
- API 응답이 성공하면 `Alert`로 친구 요청 완료 메시지를 보여주고, 실패하면 서버에서 내려준 `message`를 이용해 실패 알림 표시
- API 연결 확인을 위해 요청 URL, 보낼 친구 코드, 응답 상태 코드, 응답 데이터를 `console.log`로 출력하도록 구성

**<화면 흐름>**
- 사용자가 소셜 화면의 우측 상단 친구 추가 버튼을 누름
- `AddFriendModal` 바텀시트가 열림
- 사용자가 친구 카드의 `추가` 버튼을 누르면 친구 요청 API 호출

**참고 사항**
- 현재 둘러보기 페이지 API 연결이 되지 않은 상태이므로, 스크랩을 통한 추천 친구 목록이 뜨지 않아 실제 화면에서의 테스트는 불가. 
- 둘러보기 페이지 연결 이후 정상 작동하는지 확인할 예정.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

