### PR TITLE
refactor: 마이페이지 API 코드 & UI 코드 분리

### DIFF
--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -1,0 +1,167 @@
+import * as Securestore from "expo-secure-store";
+import {
+    MyProfileResponse,
+    PresignedUrlRequest,
+    PresignedUrlResponse,
+    ProfileEditForm,
+    ProfileUser,
+    UpdateProfileRequest,
+} from "../features/profile/types/profile.types";
+import { BASE_URL } from "./config";
+
+// 로그인 토큰 얻기
+const getAccessToken = async () => {
+    const accessToken = await Securestore.getItemAsync("accessToken");
+
+    if (!accessToken) {
+        throw new Error("로그인 토큰이 없습니다.");
+    }
+
+    return accessToken;
+};
+
+// 마이페이지 화면에서 필요한 값 매핑
+const mapMyProfileToProfileUser = (
+    data: MyProfileResponse["data"]
+): ProfileUser => {
+    return {
+        id: `#${data.userId}`,
+        name: data.nickname,
+        location: data.location || "위치 미설정",
+        passportCount: data.stats.passportCount ?? 0,
+        districtCount: data.stats.districtCount ?? 0,
+        totallike: data.stats.likeCount ?? 0,
+        profileImage: data.profileImg,
+    };
+};
+
+// 프로필 수정 화면에서 필요한 값 매핑
+const mapMyProfileToEditForm = (
+    data: MyProfileResponse["data"]
+): ProfileEditForm => {
+    return {
+        profileImg: data.profileImg,
+        email: data.email,
+        userId: `#${data.userId}`,
+        nickname: data.nickname,
+        location: data.location || "",
+        bio: data.bio || "",
+    };
+};
+
+// 프로필 조회
+const requestMyProfile = async (): Promise<MyProfileResponse> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/users/me`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    const result: MyProfileResponse = await response.json();
+
+    console.log("내 프로필 조회 상태:", response.status);
+    console.log("내 프로필 조회 응답:", result);
+
+    if (!response.ok || !result.success) {
+        throw new Error(result.message || "내 프로필 조회 실패");
+    }
+
+    return result;
+};
+
+// 1. 마이페이지 메인에서 프로필 조회
+export const getMyProfile = async (): Promise<ProfileUser> => {
+    const result = await requestMyProfile();
+
+    return mapMyProfileToProfileUser(result.data);
+};
+
+// 2. 프로필 수정 화면에서 프로필 조회
+export const getMyProfileEditForm = async (): Promise<ProfileEditForm> => {
+    const result = await requestMyProfile();
+
+    return mapMyProfileToEditForm(result.data);
+};
+
+// 3. presigned URL 발급 + S3 업로드
+export const uploadProfileImage = async (
+    imageUri: string,
+    contentType: string
+): Promise<string> => {
+    const accessToken = await getAccessToken();
+
+    const presignedResponse = await fetch(
+        `${BASE_URL}/api/v1/images/presigned-url`,
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({
+                domain: "profile",
+                contentType,
+            } satisfies PresignedUrlRequest),
+        }
+    );
+
+    const presignedResult: PresignedUrlResponse =
+        await presignedResponse.json();
+
+    console.log("Presigned URL 발급 상태:", presignedResponse.status);
+    console.log("Presigned URL 발급 응답:", presignedResult);
+
+    if (!presignedResponse.ok) {
+        throw new Error("Presigned URL 발급 실패");
+    }
+
+    const imageResponse = await fetch(imageUri);
+    const imageBlob = await imageResponse.blob();
+
+    const uploadResponse = await fetch(presignedResult.presignedUrl, {
+        method: "PUT",
+        headers: {
+            "Content-Type": contentType,
+        },
+        body: imageBlob,
+    });
+
+    console.log("S3 이미지 업로드 상태:", uploadResponse.status);
+
+    if (!uploadResponse.ok) {
+        throw new Error("S3 이미지 업로드 실패");
+    }
+
+    return presignedResult.imageUrl;
+};
+
+// 4. 프로필 수정 PUT 요청
+export const updateMyProfile = async (
+    requestBody: UpdateProfileRequest
+): Promise<ProfileEditForm> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/users/me`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(requestBody),
+    });
+
+    const result: MyProfileResponse = await response.json();
+
+    console.log("프로필 수정 상태:", response.status);
+    console.log("프로필 수정 응답:", result);
+
+    if (!response.ok || !result.success) {
+        throw new Error(result.message || "프로필 수정 실패");
+    }
+
+    return mapMyProfileToEditForm(result.data);
+};

--- a/src/features/profile/screens/ProfileEditScreen.tsx
+++ b/src/features/profile/screens/ProfileEditScreen.tsx
@@ -1,8 +1,11 @@
-import { BASE_URL } from "@/src/api/config";
+import {
+    getMyProfileEditForm,
+    updateMyProfile,
+    uploadProfileImage
+} from "@/src/api/profileApi";
 import { Ionicons } from "@expo/vector-icons";
 import * as ImagePicker from "expo-image-picker";
 import { useRouter } from "expo-router";
-import * as Securestore from "expo-secure-store";
 import { useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -16,47 +19,7 @@ import {
     TouchableOpacity,
     View
 } from "react-native";
-
-type MyProfileResponse = {
-    success: boolean;
-    code: string;
-    message: string;
-    data: {
-        userId: number;
-        nickname: string;
-        email: string;
-        profileImg: string | null;
-        friendCode: string;
-        location: string | null;
-        bio: string | null;
-        currentMode: string;
-        createdAt: string;
-        stats: {
-            friendCount: number;
-            districtCount: number;
-            passportCount: number;
-            likeCount: number;
-            scrapCount: number;
-        }
-    }
-}
-
-// 이미지 업로드 관련 타입 정의
-type PresignedUrlResponse = {
-    presignedUrl: string;
-    imageUrl: string;
-}
-type PresignedUrlRequest = {
-    domain: string;
-    contentType: string;
-}
-
-type UpdateProfileRequest = {
-    nickname: string;
-    profileImg: string | null;
-    location: string;
-    bio: string;
-}
+import { UpdateProfileRequest } from "../types/profile.types";
 export default function ProfileEditView() {
     const router = useRouter();
 
@@ -75,34 +38,16 @@ export default function ProfileEditView() {
     // 1. 내 프로필 조회 API 연결
     useEffect(() => {
         const fetchMyProfile = async () => {
-            const accessToken = await Securestore.getItemAsync("accessToken");
 
             try {
-                const response = await fetch (`${BASE_URL}/api/v1/users/me`, {
-                    method: "GET",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Authorization: `Bearer ${accessToken}`
-                    }
-                })
+                const profile = await getMyProfileEditForm();
 
-                const result: MyProfileResponse = await response.json();
-
-                console.log("프로필 수정 화면 조회 상태:", response.status);
-                console.log("프로필 수정 화면 조회 응답:", result);
-
-                if(!response.ok || !result.success) {
-                    throw new Error(result.message || "프로필 조회 실패");
-                }
-
-                const profileData = result.data;
-
-                setProfileImg(profileData.profileImg);
-                setEmail(profileData.email);
-                setUserId(`#${profileData.userId}`);
-                setNickname(profileData.nickname);
-                setLocation(profileData.location || "");
-                setBio(profileData.bio || "");
+                setProfileImg(profile.profileImg);
+                setEmail(profile.email);
+                setUserId(profile.userId);
+                setNickname(profile.nickname);
+                setLocation(profile.location || "");
+                setBio(profile.bio || "");
             } catch(error) {
                 console.log("프로필 수정 화면 조회 에러:", error)
             } finally {
@@ -113,60 +58,7 @@ export default function ProfileEditView() {
         fetchMyProfile();
     }, []);
 
-    // 2. 이미지 업로드 API 연결
-    const uploadImageToS3 = async (imageUri: string, contentType: string) => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
-
-        if(!accessToken) {
-            throw new Error("로그인 토큰이 없습니다.");
-        }
-
-        // 2-1. Presigned URL 발급 요청
-        const presignedResponse = await fetch(`${BASE_URL}/api/v1/images/presigned-url`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${accessToken}`,
-            },
-            body: JSON.stringify({
-                domain: "profile",
-                contentType,
-            } satisfies PresignedUrlRequest),
-        });
-
-        const presignedResult: PresignedUrlResponse = await presignedResponse.json();
-
-        console.log("Presigned URL 발급 상태:", presignedResponse.status);
-        console.log("Presigned URL 발급 응답:", presignedResult);
-
-        if (!presignedResponse.ok) {
-            throw new Error("Presigned URL 발급 실패");
-        }
-
-        // 2-2.로컬 이미지 파일을 blob로 변환
-        const imageResponse = await fetch(imageUri);
-        const imageBlob = await imageResponse.blob();
-
-        // 2-3. S3 presignedUrl로 실제 이미지 업로드
-        const uploadResponse = await fetch (presignedResult.presignedUrl, {
-            method: "PUT",
-            headers: {
-                "Content-Type": contentType,
-            },
-            body: imageBlob,
-        })
-
-        console.log("S3 이미지 업로드 상태:", uploadResponse.status);
-
-        if(!uploadResponse.ok) {
-            throw new Error("S3 이미지 업로드 실패");
-        }
-
-        // 2-4. DB에 저장할 이미지 조회 URL 반환
-        return presignedResult.imageUrl;
-    }
-
-    // 갤러리에서 사진 고르기
+    // 2. 갤러리에서 사진 고르기
     const handlePickImage = async () => {
 
         const previousProfileImg = profileImg;
@@ -204,7 +96,7 @@ export default function ProfileEditView() {
             setProfileImg(imageUri);
 
             // S3 업로드 후 imageUrl 받기
-            const uploadedImageUrl = await uploadImageToS3(imageUri, contentType);
+            const uploadedImageUrl = await uploadProfileImage(imageUri, contentType);
 
             console.log("업로드 완료 imageUrl:", uploadedImageUrl);
 
@@ -230,12 +122,6 @@ export default function ProfileEditView() {
         setIsSaving(true);
 
         try {
-            const accessToken = await Securestore.getItemAsync("accessToken");
-
-            if(!accessToken) {
-                throw new Error("로그인 토큰이 없습니다.");
-            }
-
             const requestBody: UpdateProfileRequest = {
                 nickname: nickname.trim(),
                 profileImg: profileImg,
@@ -245,29 +131,11 @@ export default function ProfileEditView() {
 
             console.log("프로필 수정 요청 body:", requestBody);
 
-            const response = await fetch(`${BASE_URL}/api/v1/users/me`, {
-                method: "PUT",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                },
-                body: JSON.stringify(requestBody),
-            })
-
-            const result: MyProfileResponse = await response.json();
-
-            console.log("프로필 수정 상태:", response.status);
-            console.log("프로필 수정 응답:", result)
-
-            if(!response.ok || !result.success) {
-                throw new Error(result.message || "프로필 수정 실패")
-            }
-
-            const updatedProfile = result.data;
+            const updatedProfile = await updateMyProfile(requestBody);
 
             setProfileImg(updatedProfile.profileImg)
             setEmail(updatedProfile.email)
-            setUserId(`#${updatedProfile.userId}`)
+            setUserId(updatedProfile.userId)
             setNickname(updatedProfile.nickname)
             setLocation(updatedProfile.location || "")
             setBio(updatedProfile.bio || "")

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,8 +1,7 @@
-import { BASE_URL } from "@/src/api/config";
+import { getMyProfile } from "@/src/api/profileApi";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
-import { useFocusEffect, useRouter } from "expo-router";
-import * as Securestore from "expo-secure-store";
-import { useCallback, useState } from "react";
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
 import {
     ActivityIndicator,
     Image,
@@ -20,28 +19,6 @@ import {
     settingMenuDummy
 } from "../data/profileDummy";
 import { ProfileMenuItem, ProfileUser } from "../types/profile.types";
-
-type MyProfileResponse = {
-    success: boolean;
-    code: string;
-    message: string;
-    data: {
-        userId: number;
-        nickname: string;
-        email: string;
-        profileImg: string | null;
-        friendCode: string;
-        location: string | null;
-        bio: string | null;
-        currentMode: string;
-        createdAt: string;
-        stats: {
-            districtCount: number;
-            passportCount: number;
-            likeCount: number;
-        }
-    }
-}
 
 export default function ProfileView() {
     const router = useRouter();
@@ -70,51 +47,19 @@ export default function ProfileView() {
         }
     }
 
-    // 1. 내 프로필 조회 API 연결
-    const fetchMyProfile = async () => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
-
-        try {
-            const response = await fetch(`${BASE_URL}/api/v1/users/me`, {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            });
-
-            const result: MyProfileResponse = await response.json();
-
-            console.log("내 프로필 조회 상태 코드:", response.status);
-
-            if (!response.ok || !result.success) {
-                throw new Error(result.message || "내 프로필 조회 실패");
+    useEffect(() => {
+        const fetchMyProfile = async () => {
+            try {
+                const profile = await getMyProfile();
+                setUser(profile);
+            }catch(error) {
+                console.log("내 프로필 조회 에러:", error);
+            }finally {
+                setIsLoading(false);
             }
-
-            const profileData = result.data;
-
-            setUser({
-                id: `#${profileData.userId}`,
-                name: profileData.nickname,
-                location: profileData.location || "위치 미설정",
-                passportCount: profileData.stats.passportCount ?? 0,
-                districtCount: profileData.stats.districtCount ?? 0,
-                totallike: profileData.stats.likeCount ?? 0,
-                profileImage: profileData.profileImg,
-            });
-        } catch (error) {
-            console.log("내 프로필 조회 에러:", error);
-        } finally {
-            setIsLoading(false);
         }
-    };
-
-    useFocusEffect(
-        useCallback(() => {
-            setIsLoading(true);
-            fetchMyProfile();
-        }, [])
-    );
+        fetchMyProfile();
+    },[])
 
     if (isLoading) {
         return(

--- a/src/features/profile/types/profile.types.ts
+++ b/src/features/profile/types/profile.types.ts
@@ -1,3 +1,4 @@
+// 내 프로필에 필요한 타입
 export type ProfileUser = {
     id: string;
     name: string;
@@ -8,10 +9,66 @@ export type ProfileUser = {
     profileImage: string | null;
 };
 
+// 마이페이지 목록에 필요한 타입
 export type ProfileMenuItem = {
     id: string;
     title: string;
     description?: string;
     icon: string;
     route?: string;
+};
+
+// 프로필 수정 화면에서 필요한 타입
+export type MyProfileResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: {
+        userId: number;
+        nickname: string;
+        email: string;
+        profileImg: string | null;
+        friendCode: string;
+        location: string | null;
+        bio: string | null;
+        currentMode: string;
+        createdAt: string;
+        stats: {
+            friendCount: number;
+            districtCount: number;
+            passportCount: number;
+            likeCount: number;
+            scrapCount: number;
+        };
+    };
+};
+
+// 프로필 수정 화면용 타입
+export type ProfileEditForm = {
+    profileImg: string | null;
+    email: string;
+    userId: string;
+    nickname: string;
+    location: string;
+    bio: string;
+};
+
+// 프로필 업로드 요청 타입
+export type UpdateProfileRequest = {
+    nickname: string;
+    profileImg: string | null;
+    location: string;
+    bio: string;
+};
+
+// 이미지 업로드 전 presigned url 전용 요청 타입
+export type PresignedUrlRequest = {
+    domain: string;
+    contentType: string;
+};
+
+// 이미지 업로드 전 presigned url 전용 응답 타입
+export type PresignedUrlResponse = {
+    presignedUrl: string;
+    imageUrl: string;
 };


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #46

## 📝 작업 내용
마이페이지 관련 파일에서 API 연결 코드와 UI 구현 코드를 분리하여 가독성을 높였습니다.

**<파일 역할 정리>**
`profileApi.ts`

```
서버와 통신하는 역할
토큰 가져오기
fetch 요청
응답 검증
API 응답을 화면 타입으로 변환
```

`profilesScreen.tsx`

```
마이페이지 메인 UI
getMyProfile 호출
로딩 처리
모달 열기/닫기
```

`ProfileEditScreen.tsx`

```
프로필 수정 UI
getMyProfileEditForm 호출
이미지 선택
uploadProfileImage 호출
updateMyProfile 호출
입력값 상태 관리
```


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

