### PR TITLE
feat: 좋아요/스크랩 등록 및 취소 API 연결

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,22 @@
+// src/api/axiosInstance.ts
+import axios from 'axios'
+import * as SecureStore from 'expo-secure-store'
+import { BASE_URL } from './config'
+
+const axiosInstance = axios.create({
+    baseURL: BASE_URL,
+    timeout: 10000,
+    headers: {
+        'Content-Type': 'application/json',
+    },
+})
+
+axiosInstance.interceptors.request.use(async (config) => {
+    const token = await SecureStore.getItemAsync('accessToken')
+    if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+})
+
+export default axiosInstance

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -36,8 +36,8 @@ export const API_ENDPOINTS = {
   },
 
   SCRAP: {
-    SCRAP: (passportId: number) => `/api/v1/passports/${passportId}/scrap`,
-    UNSCRAP: (passportId: number) => `/api/v1/passports/${passportId}/scrap`,
+    SCRAP: (passportId: number) => `/api/v1/passports/${passportId}/scraps`,
+    UNSCRAP: (passportId: number) => `/api/v1/passports/${passportId}/scraps`,
     GET_MY_SCRAPS: '/api/v1/passports/scraps/me',
   },
 

--- a/src/features/search/components/AllSearchContent.tsx
+++ b/src/features/search/components/AllSearchContent.tsx
@@ -1,3 +1,5 @@
+import { likePassport, unlikePassport } from "@/src/api/list/like.api";
+import { scrapPassport, unscrapPassport } from "@/src/api/list/scrap.api";
 import { getPassportFeed, requestFriend } from "@/src/api/searchApi";
 import { useEffect, useState } from "react";
 import {
@@ -40,10 +42,11 @@ export default function AllSearchContent({
     const [nextCursor, setNextCursor] = useState<number | null>(null);
     const [nextCursorScore, setNextCursorScore] = useState<number | null>(null);
 
-    const [likeIds, setLikeIds] = useState<number[]>([]);
-    const [scrappedIds, setScrappedIds] = useState<number[]>([]);
+    // 좋아요/스크랩 관련 state
+    const [likingPassportIds, setLikingPassportIds] = useState<number[]>([]);
+    const [scrappingPassportIds, setScrappingPassportIds] = useState<number[]>([]);
 
-    // 친구 추가 API 연결
+    // 1. 친구 추가 API 연결
     const handleAddFriend = async (friendCode: string) => {
         if (isRequestingFriend) return;
 
@@ -77,7 +80,7 @@ export default function AllSearchContent({
         }
     };
 
-    // 릴스 피드 조회 API 연결
+    // 2. 릴스 피드 조회 API 연결
     const fetchFeed = async (isNextPage = false) => {
         try {
             if (isNextPage) {
@@ -128,22 +131,151 @@ export default function AllSearchContent({
         fetchFeed(true);
     };
 
-    // 좋아요 
-    const toggleLike = (id: number) => {
-        setLikeIds((prev) =>
-            prev.includes(id)
-                ? prev.filter((likeId) => likeId !== id)
-                : [...prev, id]
+    // 3. 좋아요 
+    const toggleLike = async (passportId: number) => {
+        if (likingPassportIds.includes(passportId)) return;
+
+        const targetItem = feedList.find(
+            (item) => item.passportId === passportId
         );
+
+        if (!targetItem) return;
+
+        const previousIsLiked = targetItem.isLiked;
+        const previousLikeCount = targetItem.likeCount;
+
+        try {
+            setLikingPassportIds((prev) => [...prev, passportId]);
+
+            // 화면에 먼저 반영
+            setFeedList((prev) =>
+                prev.map((item) => 
+                    item.passportId === passportId
+                        ? {
+                            ...item,
+                            isLiked: !item.isLiked,
+                            likeCount: item.isLiked
+                                ? Math.max(item.likeCount - 1, 0)
+                                : item.likeCount +1
+                        }
+                        : item
+                )
+            );
+
+            // 실제 좋아요 API 호출
+            if (previousIsLiked) {
+                // 좋아요 취소
+                const response = await unlikePassport(passportId);
+
+                console.log("좋아요 취소 성공:", {
+                    passportId,
+                    status: response.status,
+                    data: response.data
+                })
+
+            } else { 
+                // 좋아요 등록
+                const response = await likePassport(passportId); 
+
+                console.log("좋아요 등록 성공:", {
+                    passportId,
+                    status: response.status,
+                    data: response.data
+                })
+            }
+        }catch(error) {
+            console.log("좋아요 처리 에러:", error);
+
+            // 실패하면 원래 상태로 복구
+            setFeedList((prev) =>
+                prev.map((item) => 
+                    item.passportId === passportId
+                        ? {
+                            ...item,
+                            isLiked: previousIsLiked,
+                            likeCount: previousLikeCount,
+                        }
+                        : item
+                )
+            )
+        }finally {
+            setLikingPassportIds((prev) =>
+                prev.filter((id) => id !== passportId)
+            )
+        }
     };
 
-    // 스크랩
-    const toggleScrap = (id: number) => {
-        setScrappedIds((prev) =>
-            prev.includes(id)
-                ? prev.filter((scrappedId) => scrappedId !== id)
-                : [...prev, id]
+    // 4. 스크랩
+    const toggleScrap = async (passportId: number) => {
+
+        if(scrappingPassportIds.includes(passportId)) return;
+
+        const targetItem = feedList.find(
+            (item) => item.passportId === passportId
         );
+
+        if(!targetItem) return;
+
+        const previousIsScrapped = targetItem.isScrapped;
+        const previousScrapCount = targetItem.scrapCount;
+
+        try {
+            setScrappingPassportIds((prev) => [...prev, passportId]);
+
+            // 화면에 먼저 반영
+            setFeedList((prev) =>
+                prev.map((item) =>
+                    item.passportId === passportId
+                        ? {
+                            ...item,
+                            isScrapped: !item.isScrapped,
+                            scrapCount: item.isScrapped
+                                ? Math.max(item.scrapCount -1, 0)
+                                : item.scrapCount+1
+                        }
+                        : item
+                )
+            )
+
+            // 실제 스크랩 API 호출
+            if(previousIsScrapped) {
+                const response = await unscrapPassport(passportId);
+
+                console.log("스크랩 취소 성공:", {
+                    passportId,
+                    status: response.status,
+                    data: response.data
+                })
+            } else {
+                const response = await scrapPassport(passportId);
+
+                console.log("스크랩 등록 성공:", {
+                    passportId,
+                    status: response.status,
+                    data: response.data
+                })
+            }
+        } catch(error: any) {
+            console.log("스크랩 처리 에러:", error);
+
+            // 실패하면 원래 상태로 복구
+            setFeedList((prev) =>
+                prev.map((item) => 
+                    item.passportId === passportId
+                        ? {
+                            ...item,
+                            isScrapped: previousIsScrapped,
+                            scrapCount: previousScrapCount,
+                        }
+                        : item
+                )
+            )
+        } finally {
+            setScrappingPassportIds((prev) => 
+                prev.filter((id) => id !== passportId)
+            )
+        }
+    
     };
 
     if (isLoading) {
@@ -195,14 +327,10 @@ export default function AllSearchContent({
                                     <PassportFrame item={item} />
 
                                     <PassportActionButtons
-                                        isLiked={
-                                            item.isLiked ||
-                                            likeIds.includes(item.passportId)
-                                        }
-                                        isScrapped={
-                                            item.isScrapped ||
-                                            scrappedIds.includes(item.passportId)
-                                        }
+                                        isLiked={item.isLiked}
+                                        isScrapped={item.isScrapped}
+                                        isLiking={likingPassportIds.includes(item.passportId)}
+                                        isScrapping={scrappingPassportIds.includes(item.passportId)}
                                         onPressLike={() => toggleLike(item.passportId)}
                                         onPressScrap={() => toggleScrap(item.passportId)}
                                     />

--- a/src/features/search/components/PassportActionButtons.tsx
+++ b/src/features/search/components/PassportActionButtons.tsx
@@ -4,6 +4,8 @@ import { StyleSheet, TouchableOpacity, View } from "react-native";
 type PassportActionButtonsProps = {
     isLiked: boolean;
     isScrapped: boolean;
+    isLiking?: boolean;
+    isScrapping?: boolean;
     onPressLike: () => void;
     onPressScrap: () => void;
 };
@@ -11,12 +13,17 @@ type PassportActionButtonsProps = {
 export default function PassportActionButtons({
     isLiked,
     isScrapped,
+    isLiking = false,
+    isScrapping = false,
     onPressLike,
     onPressScrap,
 }: PassportActionButtonsProps) {
     return (
         <View style={styles.actionButtonArea}>
-            <TouchableOpacity onPress={onPressLike}>
+            <TouchableOpacity 
+                onPress={onPressLike}
+                disabled={isLiking}
+            >
                 <Ionicons
                     name={isLiked ? "heart" : "heart-outline"}
                     size={24}
@@ -24,7 +31,10 @@ export default function PassportActionButtons({
                 />
             </TouchableOpacity>
 
-            <TouchableOpacity onPress={onPressScrap}>
+            <TouchableOpacity 
+                onPress={onPressScrap}
+                disabled={isScrapping}
+            >
                 <Ionicons
                     name={isScrapped ? "bookmark" : "bookmark-outline"}
                     size={24}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #52 

## 📝 작업 내용
좋아요/스크랩 등록 및 취소 API 연결
#### 좋아요

#### <방식>

- `src/api/list/like.api.ts`에서 좋아요 관련 API 함수를 분리.
- `axiosInstance`를 사용해서 공통 `BASE_URL`, `Authorization Bearer accessToken` 헤더가 자동으로 적용되도록 함.
- `AllSearchContent.tsx`에서는 사용자가 하트 버튼을 눌렀을 때 현재 게시글의 `isLiked` 값을 기준으로 등록/취소 API를 구분해서 호출.
- API 응답을 기다리기 전에 `feedList`의 `isLiked`, `likeCount`를 먼저 바꾸는 방식 사용.
- API 요청 실패 시에는 이전의 `isLiked`, `likeCount` 값으로 다시 복구하도록 처리.
- 중복 클릭 방지를 위해 `likingPassportIds` state를 두고, 요청 중인 게시글의 좋아요 버튼은 비활성화.
#### 스크랩

#### <방식>

- `src/api/list/scrap.api.ts`에서 스크랩 관련 API 함수를 분리.
- `axiosInstance`를 사용해서 공통 `BASE_URL`, `Authorization Bearer accessToken` 헤더가 자동으로 적용되도록 함.
- `AllSearchContent.tsx`에서는 사용자가 북마크 버튼을 눌렀을 때 현재 게시글의 `isScrapped` 값을 기준으로 등록/취소 API를 구분해서 호출.
- 좋아요와 동일하게 `feedList`의 `isScrapped`, `scrapCount`를 먼저 변경하고, 실패 시 이전 상태로 되돌리는 방식으로 구현.
- 중복 클릭 방지를 위해 `scrappingPassportIds` state를 사용했고, 요청 중인 게시글의 스크랩 버튼은 비활성화.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

