### PR TITLE
feat: 릴스 피드 스크롤 방식 개선

### DIFF
--- a/src/features/search/components/AllSearchContent.tsx
+++ b/src/features/search/components/AllSearchContent.tsx
@@ -21,6 +21,9 @@ type AllSearchContentProps = {
     setRequestedFriendCodes: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
+const SCREEN_WIDTH = Dimensions.get("window").width;
+const CARD_WIDTH = SCREEN_WIDTH - 48;
+
 // 둘러보기 메인 화면
 export default function AllSearchContent({
     requestedFriendCodes,
@@ -37,6 +40,7 @@ export default function AllSearchContent({
     const [isLoading, setIsLoading] = useState(true);
     const [isFetchingMore, setIsFetchingMore] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
+    const [listHeight, setListHeight] = useState(0);
 
     const [hasNext, setHasNext] = useState(false);
     const [nextCursor, setNextCursor] = useState<number | null>(null);
@@ -303,53 +307,63 @@ export default function AllSearchContent({
     }
 
     return (
-        <View style={styles.reelsContainer}>
-            <FlatList
-                data={feedList}
-                keyExtractor={(item) => String(item.passportId)}
-                renderItem={({ item }) => (
-                    <View style={styles.reelsPage}>
-                        <View style={styles.card}>
-                            <Image
-                                source={require("@/assets/images/noise.png")}
-                                style={styles.noiseBackground}
-                                resizeMode="cover"
-                            />
-
-                            <View style={styles.cardContent}>
-                                <SearchUserCard
-                                    item={item}
-                                    onAddFriend={handleAddFriend}
-                                    isRequested={requestedFriendCodes.includes(item.writerFriendCode)}
+        <View 
+            style={styles.reelsContainer}
+            onLayout={(event) => {
+                setListHeight(event.nativeEvent.layout.height)
+            }}
+        >
+            {listHeight > 0 && (
+                <FlatList
+                    data={feedList}
+                    keyExtractor={(item) => String(item.passportId)}
+                    renderItem={({ item }) => (
+                        <View style={[styles.reelsPage, { height: listHeight }]}>
+                            <View style={[styles.card, { height: listHeight - 16 }]}>
+                                <Image
+                                    source={require("@/assets/images/noise.png")}
+                                    style={styles.noiseBackground}
+                                    resizeMode="cover"
                                 />
 
-                                <View style={styles.passportDetailArea}>
-                                    <PassportFrame item={item} />
-
-                                    <PassportActionButtons
-                                        isLiked={item.isLiked}
-                                        isScrapped={item.isScrapped}
-                                        isLiking={likingPassportIds.includes(item.passportId)}
-                                        isScrapping={scrappingPassportIds.includes(item.passportId)}
-                                        onPressLike={() => toggleLike(item.passportId)}
-                                        onPressScrap={() => toggleScrap(item.passportId)}
+                                <View style={styles.cardContent}>
+                                    <SearchUserCard
+                                        item={item}
+                                        onAddFriend={handleAddFriend}
+                                        isRequested={requestedFriendCodes.includes(item.writerFriendCode)}
                                     />
+
+                                    <View style={styles.passportDetailArea}>
+                                        <PassportFrame item={item} />
+
+                                        <PassportActionButtons
+                                            isLiked={item.isLiked}
+                                            isScrapped={item.isScrapped}
+                                            isLiking={likingPassportIds.includes(item.passportId)}
+                                            isScrapping={scrappingPassportIds.includes(item.passportId)}
+                                            onPressLike={() => toggleLike(item.passportId)}
+                                            onPressScrap={() => toggleScrap(item.passportId)}
+                                        />
+                                    </View>
                                 </View>
                             </View>
                         </View>
-                    </View>
-                )}
-                pagingEnabled
-                showsVerticalScrollIndicator={false}
-                decelerationRate="fast"
-                onEndReached={handleEndReached}
-                onEndReachedThreshold={0.5}
-                ListFooterComponent={
-                    isFetchingMore ? (
-                        <ActivityIndicator size="small" color="#1A3A6B" />
-                    ) : null
-                }
-            />
+                    )}
+                    pagingEnabled
+                    snapToInterval={listHeight}
+                    snapToAlignment="start"
+                    decelerationRate="fast"
+                    disableIntervalMomentum
+                    showsVerticalScrollIndicator={false}
+                    onEndReached={handleEndReached}
+                    onEndReachedThreshold={0.5}
+                    ListFooterComponent={
+                        isFetchingMore ? (
+                            <ActivityIndicator size="small" color="#1A3A6B" />
+                        ) : null
+                    }
+                />
+            )}
 
             {showAddMessage && (
                 <View style={styles.addMessageBox}>
@@ -384,14 +398,13 @@ const styles = StyleSheet.create({
         position: "relative",
     },
     reelsPage: {
-        height: Dimensions.get("window").height - 150,
-        paddingHorizontal: 20,
-        paddingBottom: 24,
+        justifyContent: "center",
+        alignItems: "center",
+        paddingHorizontal: 24,
     },
     card: {
-        flex: 1,
+        width: CARD_WIDTH,
         position: "relative",
-        width: "100%",
         backgroundColor: "#F8FAFD",
         borderRadius: 16,
         shadowColor: "#000000",

--- a/src/features/search/components/PassportFrame.tsx
+++ b/src/features/search/components/PassportFrame.tsx
@@ -41,6 +41,7 @@ export default function PassportFrame({item}: PassportFrameProps) {
           />
 
           <View style={styles.infoArea}>
+            <Text style={styles.infoRow}>🏷 {item.categoryDisplayName || item.category}</Text>
             <Text style={styles.infoRow}>📍 {item.spaceName}</Text>
             <Text style={styles.infoRow}>🗓 {item.visitedAt}</Text>
           </View>


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #52 

## 📝 작업 내용
1. 릴스 피드 조회 스크롤 방식 개선
2. 카테고리 필드 추가

#### <스크롤 관련 수정>

- 기존: `pagingEnabled`만 사용 → but, 스크롤을 빠르게 하면 여러 개의 여권이 한 번에 넘어가거나 이전 여권의 일부가 겹처 보이는 문제가 존재
- 수정:
1. `FlatList`의 실제 높이를 `onLayout`으로 측정해서 `listHeight` state에 저장 → `reelsPage`, `card`, `snapToInterval`에 모두 동일한 높이 값을 적용
2. `disableIntervalMomentum` 옵션을 추가해서 사용자가 세게 스크롤해도 한 번에 한 페이지씩만 이동하도록 개선

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

