### PR TITLE
refactor: 소셜페이지 API 코드 분리

### DIFF
--- a/src/api/socialApi.ts
+++ b/src/api/socialApi.ts
@@ -1,0 +1,168 @@
+import {
+    Friend,
+    MutualFriend,
+    RecommendedFriend,
+} from "@/src/features/social/types/social.types";
+import * as Securestore from "expo-secure-store";
+import { BASE_URL } from "./config";
+
+type FriendApiItem = {
+    friendId: number;
+    userId: number;
+    nickname: string;
+    profileImg: string | null;
+    friendCode: string;
+    status: string;
+    createdAt: string;
+    stampCount: number;
+    passportCount: number;
+    mutualFriends: MutualFriend[];
+};
+
+type FriendListResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: FriendApiItem[];
+}
+
+type RecommendedFriendResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: RecommendedFriend[];
+};
+
+type SearchFriendResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: RecommendedFriend;
+};
+
+type FriendRequestResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: unknown;
+}
+
+// 1. 토큰 발급
+const getAccessToken = async () => {
+    const accessToken = await Securestore.getItemAsync("accessToken");
+
+    if(!accessToken) {
+        throw new Error("로그인 토큰이 없습니다.");
+    }
+
+    return accessToken;
+}
+const authHeaders = async () => {
+    const accessToken = await getAccessToken();
+
+    return {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+    }
+}
+
+// 2. 백엔드 response 프론트 타입과 매핑
+const mapFriendApiItemToFriend = (item: FriendApiItem): Friend => {
+    return {
+        id: String(item.friendId),
+        friendId: item.friendId,
+        userId: item.userId,
+        name: item.nickname,
+        profileImg: item.profileImg,
+        friendCode: item.friendCode,
+        status: item.status,
+        createdAt: item.createdAt,
+
+        stampCount: item.stampCount,
+        passportCount: item.passportCount,
+        mutualFriends: item.mutualFriends ?? [],
+    }
+}
+
+// 3. 친구 목록 조회
+export const getFriends = async (): Promise<Friend[]> => {
+    const response = await fetch(`${BASE_URL}/api/v1/friends`, {
+        method: "GET",
+        headers: await authHeaders()
+    });
+
+    const data: FriendListResponse = await response.json();
+
+    console.log("친구 목록 응답 상태:", response.status);
+    console.log("친구 목록 응답 데이터:", data);
+
+    if(!response.ok || !data.success) {
+        throw new Error(data.message || "친구 목록 조회에 실패했습니다.");
+    }
+
+    return data.data.map(mapFriendApiItemToFriend);
+};
+
+// 4. 추천 친구 목록 조회
+export const getRecommendedFriends = async (): Promise<RecommendedFriend[]> => {
+    const response = await fetch(`${BASE_URL}/api/v1/friends/recommendations`, {
+        method: "GET",
+        headers: await authHeaders()
+    })
+
+    const data: RecommendedFriendResponse = await response.json();
+
+    console.log("추천 친구 응답 상태:", response.status);
+    console.log("추천 친구 응답 데이터:", data);
+
+    if(!response.ok || !data.success) {
+        throw new Error(data.message || "추천 친구 목록 조회 실패");
+    }
+
+    return data.data;
+};
+
+// 5. 친구 코드 검색
+export const searchFriendByCode = async (
+    code: string
+): Promise<RecommendedFriend> => {
+    const requestUrl = `${BASE_URL}/api/v1/friends/search?code=${encodeURIComponent(code)}`;
+
+    const response = await fetch(requestUrl, {
+        method: "GET",
+        headers: await authHeaders(),
+    });
+
+    const data: SearchFriendResponse = await response.json();
+
+    console.log("친구 코드 검색 응답 상태:", response.status);
+    console.log("친구 코드 검색 응답 데이터:", data);
+
+    if (!response.ok || !data.success) {
+        throw new Error(data.message || "친구 검색 실패");
+    }
+
+    return data.data;
+};
+
+// 6. 친구 요청 보내기
+export const requestFriend = async (friendCode: string) => {
+    const response = await fetch(`${BASE_URL}/api/v1/friends/request`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+            friendCode,
+        }),
+    });
+
+    const data: FriendRequestResponse = await response.json();
+
+    console.log("친구 요청 응답 상태:", response.status);
+    console.log("친구 요청 응답 데이터:", data);
+
+    if (!response.ok || !data.success) {
+        throw new Error(data.message || "친구 요청에 실패했습니다.");
+    }
+
+    return data.data;
+};

--- a/src/features/social/components/AddFriendModal.tsx
+++ b/src/features/social/components/AddFriendModal.tsx
@@ -12,66 +12,36 @@ import {
     View
 } from "react-native";
 
-import { BASE_URL } from "@/src/api/config";
-import * as Securestore from "expo-secure-store";
+import {
+    getRecommendedFriends,
+    requestFriend,
+    searchFriendByCode,
+} from "@/src/api/socialApi";
 import { RecommendedFriend } from "../types/social.types";
 import AddFriendCard from "./AddFriendCard";
 
 type AddFriendModalProps = {
     visible: boolean,
-    onClose: () => void
+    onClose: () => void;
+    onFriendRequestSuccess?: () => void;
 };
 
-type RecommendedFriendsResponse = {
-    success: boolean;
-    code: string;
-    message: string;
-    data: RecommendedFriend[];
-}
-
-type SearchFriendResponse = {
-    success: boolean;
-    code: string;
-    message: string;
-    data: RecommendedFriend;
-}
-
-export default function AddFriendModal({visible, onClose}: AddFriendModalProps) {
+export default function AddFriendModal({visible, onClose, onFriendRequestSuccess}: AddFriendModalProps) {
 
     const [keyword, setKeyword] = useState("");
     const [friends, setFriends] = useState<RecommendedFriend[]>([]);
     const [loading, setLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
 
-    // 1. 추천 친구 목록 받아오기 API 연결
+    // 1. 추천 친구 목록 받아오기 
     const fetchRecommendedFriends = async () => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
 
         try {
             setLoading(true);
             setErrorMessage("");
 
-            console.log("추천 친구 목록 조회 시작");
-            console.log("추천 친구 목록 조회 요청 URL:", `${BASE_URL}/api/v1/friends/recommendations`)
-
-            const response = await fetch(`${BASE_URL}/api/v1/friends/recommendations`, {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                }
-            });
-
-            const data: RecommendedFriendsResponse = await response.json();
-
-            console.log("추천 친구 응답 상태:",response.status);
-            console.log("추천 친구 응답 데이터:", data);
-
-            if (!response.ok || !data.success) {
-                throw new Error(data.message || "추천 친구 목록 조회 실패"); 
-            }
-
-            setFriends(data.data)
+            const recommendedFriends = await getRecommendedFriends();
+            setFriends(recommendedFriends);
         }catch(error) {
             console.log("추천 친구 목록 조회 에러:", error);
             setErrorMessage("추천 친구 목록을 불러오지 못했습니다.");
@@ -87,9 +57,8 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
         fetchRecommendedFriends();
     }, [visible]);
 
-    // 2. 친구코드로 검색하는 API 연결
+    // 2. 친구코드로 검색
     const handleSearchFriends = async () => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
         const trimmedKeyword = keyword.trim();
 
         if(trimmedKeyword.length === 0) {
@@ -102,29 +71,8 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
             setLoading(true);
             setErrorMessage("");
 
-            const requestUrl = `${BASE_URL}/api/v1/friends/search?code=${encodeURIComponent(trimmedKeyword)}`;
-
-            console.log("친구 코드 검색 시작");
-            console.log("친구 코드 검색 요청 URL:", requestUrl);
-            
-            const response = await fetch(requestUrl, {
-                method: "GET",
-                headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                }
-            });
-
-            const data: SearchFriendResponse = await response.json();
-
-            console.log("친구 코드 검색 응답 상태:", response.status);
-            console.log("친구 코드 검색 응답 데이터:", data);
-
-            if(!response.ok || !data.success) {
-                throw new Error(data.message || "친구 검색 실패");
-            }
-
-            setFriends([data.data])
+            const searchedFriend = await searchFriendByCode(trimmedKeyword);
+            setFriends([searchedFriend])
         }catch (error) {
             console.log("친구 코드 검색 에러:", error);
             setFriends([]);
@@ -144,36 +92,13 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
         }
     }
 
-    // 3. 친구 추가하는 API 연결
+    // 3. 친구 추가
     const handleAddFriend = async (friend: RecommendedFriend) => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
-
+    
         try {
-            const requestUrl = `${BASE_URL}/api/v1/friends/request`;
-
-            console.log("친구 요청 시작");
-            console.log("친구 요청 URL:", requestUrl)
             console.log("보낼 친구 코드:", friend.friendCode);
 
-            const response = await fetch(requestUrl, {
-                method: "POST",
-                headers: {
-                    "Contetnt-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                },
-                body: JSON.stringify({
-                    friendCode: friend.friendCode,
-                })
-            })
-
-            const data = await response.json();
-
-            console.log("친구 요청 응답 상태:", response.status);
-            console.log("친구 요청 응답 데이터:", data);
-
-            if(!response.ok || !data.success) {
-                throw new Error(data.message || "친구 요청에 실패했습니다.")
-            }
+            await requestFriend(friend.friendCode);
 
             Alert.alert(
                 "친구 요청 완료!",
@@ -182,6 +107,8 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
 
             // 친구 요청 성공 후 추천 친구 목록 다시 불러오기
             fetchRecommendedFriends();
+
+            onFriendRequestSuccess?.();
         } catch(error) {
             console.log("친구 요청 에러:", error)
 
@@ -233,7 +160,7 @@ export default function AddFriendModal({visible, onClose}: AddFriendModalProps) 
                             )} 
                             showsVerticalScrollIndicator={false}
                             ListEmptyComponent={
-                                <Text style={styles.emptyText}>검색 결과가 없습니다.</Text>
+                                <Text style={styles.emptyText}>{errorMessage || "검색 결과가 없습니다."}</Text>
                             }
                         />
                     )}

--- a/src/features/social/components/FriendDetailModal.tsx
+++ b/src/features/social/components/FriendDetailModal.tsx
@@ -29,6 +29,8 @@ export default function FriendDetailModal({
     const snapPoints = useMemo(() => ["70%", "95%"], []);
     const bottomSheetRef = useRef<BottomSheet>(null);
 
+    const defaultProfile = require("../../../../assets/images/default_profile.png");
+
     if (!visible || !friend) return null;
 
     return (
@@ -62,7 +64,14 @@ export default function FriendDetailModal({
                     <Ionicons name="close" size={28} color="#FFFFFF" />
                 </TouchableOpacity>
                 <View style={styles.profileArea}>
-                    <Image source={friend.image} style={styles.profileImage} />
+                    <Image 
+                        source={
+                            friend.profileImg
+                                ? {uri: friend.profileImg}
+                                : defaultProfile
+                        } 
+                        style={styles.profileImage} 
+                    />
 
                     <View style={styles.profileTextArea}>
                         <Text style={styles.name}>

--- a/src/features/social/screens/socialScreen.tsx
+++ b/src/features/social/screens/socialScreen.tsx
@@ -1,6 +1,5 @@
-import { BASE_URL } from "@/src/api/config";
+import { getFriends } from "@/src/api/socialApi";
 import { Ionicons } from "@expo/vector-icons";
-import * as Securestore from "expo-secure-store";
 import { useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -9,30 +8,6 @@ import FriendDetailModal from "../components/FriendDetailModal";
 import FriendGrid from "../components/FriendGrid";
 import SocialSearchBar from "../components/SocialSearchBar";
 import { Friend } from "../types/social.types";
-
-type FriendApiItem = {
-    friendId: number;
-    userId: number;
-    nickname: string;
-    profileImg: string | null;
-    friendCode: string;
-    status: string;
-    createdAt: string;
-    stampCount: number;
-    passportCount: number;
-    mutualFriends: {
-        userId: number;
-        nickname: string;
-        profileImg: string | null;
-    }[];
-}
-
-type FriendListResponse = {
-    success: boolean;
-    code: string;
-    message: string;
-    data: FriendApiItem[];
-}
 
 export default function SocialView() {
     const [keyword, setKeyword] = useState("");
@@ -45,49 +20,15 @@ export default function SocialView() {
     // 친구 추가에서 선택
     const [isAddFriendOpen, setIsAddFriendOpen] = useState(false);
 
-    // 친구 목록 불러오기 API 연결
+    // 친구 목록 불러오기
     const fetchFriends = async () => {
-        const accessToken = await Securestore.getItemAsync("accessToken");
 
         try {
             setIsLoading(true);
             setErrorMessage("");
 
-            console.log("친구 목록 요청 URL:", `${BASE_URL}/api/v1/friends`);
-
-            const response = await fetch(`${BASE_URL}/api/v1/friends`, {
-                method: "GET",
-                headers : {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            });
-
-            const data: FriendListResponse = await response.json();
-
-            console.log("친구 목록 응답 상태:", response.status);
-            console.log("친구 목록 응답 데이터:",data);
-
-            if(!response.ok || !data.success) {
-                throw new Error(data.message || "친구 목록 조회에 실패했습니다.")
-            }
-
-            const mappedFriends: Friend[] = data.data.map((item) => ({
-                id: String(item.friendId),
-                friendId: item.friendId,
-                userId: item.userId,
-                name: item.nickname,
-                profileImg: item.profileImg,
-                friendCode: item.friendCode,
-                status: item.status,
-                createdAt: item.createdAt,
-
-                stampCount: item.stampCount,
-                passportCount: item.passportCount,
-                mutualFriends: item.mutualFriends ?? [],
-            }));
-
-            setFriends(mappedFriends);
+            const friendList = await getFriends();
+            setFriends(friendList);
         }catch(error) {
             console.log("친구 목록 조회 에러:", error)
             setErrorMessage("친구 목록을 불러오지 못했습니다.");
@@ -167,6 +108,7 @@ export default function SocialView() {
             <AddFriendModal
                 visible={isAddFriendOpen}
                 onClose={() => setIsAddFriendOpen(false)}
+                onFriendRequestSuccess={fetchFriends}
             />
         </SafeAreaView>
     );

--- a/src/features/social/types/social.types.ts
+++ b/src/features/social/types/social.types.ts
@@ -1,4 +1,3 @@
-import { ImageSourcePropType } from "react-native";
 
 export type MutualFriend = {
     userId: number;
@@ -19,9 +18,6 @@ export type Friend = {
     stampCount: number; // 도장 개수
     passportCount: number; // 여권 개수
     mutualFriends?: MutualFriend[]; // 함께 아는 친구
-
-    image?: ImageSourcePropType; // 사진
-    isSelected?: boolean; // 카드 선택되었을 때
 };
 
 export type RecommendedFriend = {
@@ -35,5 +31,4 @@ export type RecommendedFriend = {
 
     stampCount?: number; // 도장 개수
     mutualFriends?: MutualFriend[]; // 함께 아는 친구
-    image?: ImageSourcePropType; // 사진
 }


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #43 

## 📝 작업 내용
소셜 페이지 코드 리팩토링
소셜 화면(`socialScreen.tsx`)에 직접 들어가 있던 API 호출 로직을 별도 파일로 분리함.

기존: `SocialView`, `AddFriendModal`컴포넌트 안에서 친구 목록 조회, 추천 친구 조회, 친구 검색, 친구 요청 API를 직접 호출했었음.

리팩토링 후: `socialApi.ts` 파일을 새로 만들어 API 관련 함수를 분리함.

```tsx
getFriends() // 친구 목록
getRecommendedFriends() // 추천 친구 목록
searchFriendByCode() // 친구 코드 검색
requestFriend() // 친구 추가 요청
```

각 함수는 SecureStore에서 accessToken을 가져와 Authorization 헤더를 설정하고, 백엔드 API를 호출한 뒤 응답 데이터를 프론트에서 사용하는 타입에 맞게 반환한다.

특히 친구 목록 조회의 경우 백엔드 응답 데이터인 nickname, profileImg, friendId 등을 프론트 화면에서 사용하는 name, profileImg, id 형태로 매핑하도록 정리하였다.

`SocialView`는 getFriends()를 호출해 친구 목록만 받아오고, `AddFriendModal`은 getRecommendedFriends(), searchFriendByCode(), requestFriend()를 호출하는 방식으로 변경하였다.

결과:
컴포넌트: 화면 상태 관리/렌더링
socialApi.ts: API 요청 로직 관리

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

