### PR TITLE
feat: 친구 삭제 API & 공개 프로필 조회 API 연결

### DIFF
--- a/src/api/socialApi.ts
+++ b/src/api/socialApi.ts
@@ -1,11 +1,13 @@
 import {
     Friend,
     MutualFriend,
-    RecommendedFriend,
+    PublicUserProfile,
+    RecommendedFriend
 } from "@/src/features/social/types/social.types";
 import * as Securestore from "expo-secure-store";
 import { BASE_URL } from "./config";
 
+// 친구 타입
 type FriendApiItem = {
     friendId: number;
     userId: number;
@@ -19,6 +21,7 @@ type FriendApiItem = {
     mutualFriends: MutualFriend[];
 };
 
+// 친구 목록 타입
 type FriendListResponse = {
     success: boolean;
     code: string;
@@ -26,6 +29,7 @@ type FriendListResponse = {
     data: FriendApiItem[];
 }
 
+// 추천 친구 목록 타입
 type RecommendedFriendResponse = {
     success: boolean;
     code: string;
@@ -33,6 +37,7 @@ type RecommendedFriendResponse = {
     data: RecommendedFriend[];
 };
 
+// 친구 검색 타입
 type SearchFriendResponse = {
     success: boolean;
     code: string;
@@ -40,11 +45,32 @@ type SearchFriendResponse = {
     data: RecommendedFriend;
 };
 
+// 친구 추가 타입
 type FriendRequestResponse = {
     success: boolean;
     code: string;
     message: string;
     data: unknown;
+}
+
+// 친구 삭제 타입
+type DeleteFriendResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data: unknown;
+}
+
+// 공개 프로필 타입
+type PublicUserProfileResponse = {
+    success: boolean;
+    code: string;
+    message: string;
+    data : {
+        userId: number;
+        nickname: string;
+        profileImg: string | null;
+    }
 }
 
 // 1. 토큰 발급
@@ -166,3 +192,43 @@ export const requestFriend = async (friendCode: string) => {
 
     return data.data;
 };
+
+// 7. 친구 삭제
+export const deleteFriend = async (friendId: number) => {
+    const response = await fetch(`${BASE_URL}/api/v1/friends/${friendId}`, {
+        method: "DELETE",
+        headers: await authHeaders(),
+    });
+
+    const data: DeleteFriendResponse = await response.json();
+
+    console.log("친구 삭제 응답 상태:", response.status);
+    console.log("친구 삭제 응답 데이터:", data);
+
+    if(!response.ok || !data.success) {
+        throw new Error(data.message || "친구 삭제에 실패했습니다.");
+    }
+
+    return data.data;
+}
+
+// 8. 다른 사용자 공개 프로필 조회
+export const getPublicUserProfile = async (
+    userId: number
+): Promise<PublicUserProfile> => {
+    const response = await fetch(`${BASE_URL}/api/v1/users/${userId}`, {
+        method: "GET",
+        headers: await authHeaders(),
+    });
+
+    const data: PublicUserProfileResponse = await response.json()
+
+    console.log("공개 프로필 조회 응답 상태:", response.status);
+    console.log("공개 프로필 조회 응답 데이터:", data);
+
+    if(!response.ok || !data.success) {
+        throw new Error(data.message || "사용자 프로필 조회에 실패했습니다.")
+    }
+
+    return data.data;
+}

--- a/src/features/social/components/AddFriendCard.tsx
+++ b/src/features/social/components/AddFriendCard.tsx
@@ -26,11 +26,16 @@ const getMutualFriendText = (
 type AddFriendProps = {
     friend: RecommendedFriend;
     onAdd: (friend: RecommendedFriend) => void;
+    onPress: (friend: RecommendedFriend) => void;
 };
 
-export default function AddFriendCard({friend, onAdd}: AddFriendProps) {
+export default function AddFriendCard({friend, onAdd, onPress}: AddFriendProps) {
     return (
-        <View style={styles.card}>
+        <TouchableOpacity 
+            style={styles.card}
+            activeOpacity={0.8}
+            onPress={() => onPress(friend)}
+        >
             <Image 
                 source={
                     friend.profileImg
@@ -50,7 +55,7 @@ export default function AddFriendCard({friend, onAdd}: AddFriendProps) {
             <TouchableOpacity style={styles.addButton} onPress={() => onAdd(friend)}>
                 <Text style={styles.addButtonText}>추가</Text>
             </TouchableOpacity>
-        </View>
+        </TouchableOpacity>
     )
 }
 

--- a/src/features/social/components/AddFriendModal.tsx
+++ b/src/features/social/components/AddFriendModal.tsx
@@ -13,12 +13,14 @@ import {
 } from "react-native";
 
 import {
+    getPublicUserProfile,
     getRecommendedFriends,
     requestFriend,
-    searchFriendByCode,
+    searchFriendByCode
 } from "@/src/api/socialApi";
-import { RecommendedFriend } from "../types/social.types";
+import { PublicUserProfile, RecommendedFriend } from "../types/social.types";
 import AddFriendCard from "./AddFriendCard";
+import PublicUserProfileModal from "./PublicUserProfileModal";
 
 type AddFriendModalProps = {
     visible: boolean,
@@ -32,6 +34,9 @@ export default function AddFriendModal({visible, onClose, onFriendRequestSuccess
     const [friends, setFriends] = useState<RecommendedFriend[]>([]);
     const [loading, setLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
+
+    const [selectedUser, setSelectedUser] = useState<PublicUserProfile | null>(null);
+    const [profileLoading, setProfileLoading] = useState(false);
 
     // 1. 추천 친구 목록 받아오기 
     const fetchRecommendedFriends = async () => {
@@ -120,7 +125,30 @@ export default function AddFriendModal({visible, onClose, onFriendRequestSuccess
         }
     };
 
+    // 4. 공개 프로필 조회
+    const handlePressFriendCard = async (friend: RecommendedFriend) => {
+        try {
+            setProfileLoading(true);
+
+            console.log("조회할 사용자 userId:", friend.userId);
+
+            const profile = await getPublicUserProfile(friend.userId);
+            setSelectedUser(profile);
+        }catch(error) {
+            console.log("공개 프로필 조회 에러:", error);
+
+            if(error instanceof Error) {
+                Alert.alert("프로필 조회 실패:", error.message);
+            } else {
+                Alert.alert("프로필 조회 실패", "알 수 없는 오류가 발생했습니다.")
+            }
+        } finally {
+            setProfileLoading(false);
+        }
+    }
+
     return (
+        <>
         <Modal
             visible={visible}
             transparent
@@ -156,7 +184,11 @@ export default function AddFriendModal({visible, onClose, onFriendRequestSuccess
                             data={friends}
                             keyExtractor={(item) => String(item.friendId)}
                             renderItem={({item}) => (
-                                <AddFriendCard friend={item} onAdd={handleAddFriend} />
+                                <AddFriendCard 
+                                    friend={item} 
+                                    onAdd={handleAddFriend}
+                                    onPress={handlePressFriendCard} 
+                                />
                             )} 
                             showsVerticalScrollIndicator={false}
                             ListEmptyComponent={
@@ -184,6 +216,13 @@ export default function AddFriendModal({visible, onClose, onFriendRequestSuccess
                 </View>
             </View>
         </Modal>
+
+        <PublicUserProfileModal
+            visible={selectedUser !== null}
+            user={selectedUser}
+            onClose={() => setSelectedUser(null)}
+        />
+        </>
         
     )
 }

--- a/src/features/social/components/FriendCard.tsx
+++ b/src/features/social/components/FriendCard.tsx
@@ -5,6 +5,7 @@ type FriendCardProps = {
     friend: Friend;
     isSelected: boolean;
     onPress: () => void;
+    onLongPress: () => void;
 };
 
 const defaultProfile = require("../../../../assets/images/default_profile.png");
@@ -23,7 +24,7 @@ const getMutualFriendText = (
     return `${mutualFriends[0].nickname} 외 ${mutualFriends.length -1}명과 함께 `;
 };
 
-export default function FriendCard({friend, isSelected, onPress}: FriendCardProps) {
+export default function FriendCard({friend, isSelected, onPress, onLongPress}: FriendCardProps) {
     return(
         <TouchableOpacity
             activeOpacity={0.8}
@@ -32,13 +33,17 @@ export default function FriendCard({friend, isSelected, onPress}: FriendCardProp
                 isSelected && styles.selectedCard,
             ]}
             onPress={onPress}
+            onLongPress={onLongPress}
+            delayLongPress={500}
         >
             <Image 
                 source={
                     friend.profileImg
                         ? {uri: friend.profileImg}
                         : defaultProfile
-                } style={styles.profileImage} />
+                } 
+                style={styles.profileImage} 
+            />
             <Text style={styles.name}>{friend.name}</Text>
             <Text style={styles.stampText}>도장 {friend.stampCount ?? 0}개</Text>
             <Text style={styles.togetherText}>

--- a/src/features/social/components/FriendGrid.tsx
+++ b/src/features/social/components/FriendGrid.tsx
@@ -6,9 +6,10 @@ type FriendGridProps = {
     friends: Friend[];
     selectedFriendId: string | null;
     onPressFriend: (friend: Friend) => void;
+    onLongPressFriend: (Friend: Friend) => void;
 };
 
-export default function FriendGrid({friends, selectedFriendId, onPressFriend}: FriendGridProps) {
+export default function FriendGrid({friends, selectedFriendId, onPressFriend, onLongPressFriend}: FriendGridProps) {
     return (
     <FlatList<Friend>
         data={friends}
@@ -19,6 +20,7 @@ export default function FriendGrid({friends, selectedFriendId, onPressFriend}: F
             friend={item} 
             isSelected={item.id === selectedFriendId}
             onPress={() => onPressFriend(item)}
+            onLongPress={() => onLongPressFriend(item)}
         />}
         columnWrapperStyle={styles.row}
         contentContainerStyle={styles.contentContainer}

--- a/src/features/social/components/PublicUserProfileModal.tsx
+++ b/src/features/social/components/PublicUserProfileModal.tsx
@@ -1,0 +1,103 @@
+import { Ionicons } from "@expo/vector-icons";
+import {
+    Image,
+    Modal,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import { PublicUserProfile } from "../types/social.types";
+
+const defaultProfile = require("../../../../assets/images/default_profile.png");
+
+type PublicUserProfileModalProps = {
+    visible: boolean;
+    user: PublicUserProfile | null;
+    onClose: () => void;
+};
+
+export default function PublicUserProfileModal({
+    visible,
+    user,
+    onClose,
+} : PublicUserProfileModalProps) {
+    return(
+        <Modal
+            visible={visible}
+            transparent
+            animationType="fade"
+            onRequestClose={onClose}
+        >
+            <View style={styles.overlay}>
+                <View style={styles.modal}>
+                    <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+                        <Ionicons name="close" size={20} color="#FFFFFF" />
+                    </TouchableOpacity>
+
+                    <Image
+                        source={
+                            user?.profileImg
+                                ? {uri: user.profileImg}
+                                : defaultProfile
+                        }
+                        style={styles.profileImage}
+                    />
+
+                    <Text style={styles.nickname}>
+                        {user?.nickname ?? "사용자"}
+                    </Text>
+
+                    <Text style={styles.userId}>
+                        #{user?.userId}
+                    </Text>
+                </View>
+            </View>
+        </Modal>
+    )
+}
+
+const styles = StyleSheet.create({
+    overlay: {
+        flex: 1,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 24,
+    },
+    modal: {
+        width: "100%",
+        backgroundColor: "#FFFFFF",
+        borderRadius: 20,
+        paddingHorizontal: 20,
+        paddingVertical: 28,
+        alignItems: "center",
+    },
+    closeButton : {
+        position: "absolute",
+        right: 16,
+        top: 16,
+        width: 32,
+        height: 32,
+        borderRightColor: "#1A3A6B",
+        borderRadius: 16,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    profileImage: {
+        width: 90,
+        height: 90,
+        borderRadius: 45,
+        marginBottom: 14,
+    },
+    nickname: {
+        fontSize: 18,
+        fontWeight: "700",
+        color: "#111827",
+    },
+    userId: {
+        marginTop: 6,
+        fontSize: 13,
+        color: "#6B7280",
+    }
+})

--- a/src/features/social/screens/socialScreen.tsx
+++ b/src/features/social/screens/socialScreen.tsx
@@ -1,7 +1,7 @@
-import { getFriends } from "@/src/api/socialApi";
+import { deleteFriend, getFriends } from "@/src/api/socialApi";
 import { Ionicons } from "@expo/vector-icons";
 import { useEffect, useMemo, useState } from "react";
-import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Alert, Modal, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import AddFriendModal from "../components/AddFriendModal";
 import FriendDetailModal from "../components/FriendDetailModal";
@@ -20,6 +20,10 @@ export default function SocialView() {
     // 친구 추가에서 선택
     const [isAddFriendOpen, setIsAddFriendOpen] = useState(false);
 
+    // 삭제할 친구
+    const [deleteTargetFriend, setDeleteTargetFriend] = useState<Friend | null>(null);
+    const [isDeleteFriend, setIsDeleteFriend] = useState(false);
+
     // 친구 목록 불러오기
     const fetchFriends = async () => {
 
@@ -34,6 +38,34 @@ export default function SocialView() {
             setErrorMessage("친구 목록을 불러오지 못했습니다.");
         }finally {
             setIsLoading(false);
+        }
+    }
+
+    // 친구 삭제 호출
+    const handleDeleteFriend = async () => {
+        if(!deleteTargetFriend) return;
+
+        try {
+            setIsDeleteFriend(true);
+
+            await deleteFriend(deleteTargetFriend.friendId);
+
+            setFriends((prevFriends) =>
+                prevFriends.filter(
+                    (friend) => friend.friendId !== deleteTargetFriend.friendId
+                )
+            );
+
+            if (selectedFriend?.friendId === deleteTargetFriend.friendId) {
+                setSelectedFriend(null);
+            }
+
+            setDeleteTargetFriend(null);
+        } catch(error) {
+            console.log("친구 삭제 에러:", error);
+            Alert.alert("삭제 실패", "친구 삭제 중 문제가 발생했습니다.");
+        } finally {
+            setIsDeleteFriend(false);
         }
     }
 
@@ -94,8 +126,49 @@ export default function SocialView() {
                     friends={filteredFriends}
                     selectedFriendId={selectedFriend?.id ?? null}
                     onPressFriend={(friend) => setSelectedFriend(friend)}
+                    onLongPressFriend={(friend) => setDeleteTargetFriend(friend)}
                 />
             )}
+
+            {/*친구 삭제 확인 모달*/}
+            <Modal
+                visible={deleteTargetFriend !== null}
+                transparent
+                animationType="fade"
+                onRequestClose={() => setDeleteTargetFriend(null)}
+            >
+                <View style={styles.modalOverlay}>
+                    <View style={styles.deleteModal}>
+                        <Text style={styles.deleteTitle}>친구를 삭제하시겠습니까?</Text>
+
+                        <Text style={styles.deleteMessage}>
+                            {deleteTargetFriend?.name}님을 친구 목록에서 삭제합니다.
+                        </Text>
+
+                        <View style={styles.deleteButtonRow}>
+                            <TouchableOpacity
+                                style={styles.cancelButton}
+                                onPress={() => setDeleteTargetFriend(null)}
+                                disabled={isDeleteFriend}
+                            >
+                                <Text style={styles.cancelButtonText}>취소</Text>
+                            </TouchableOpacity>
+
+                            <TouchableOpacity
+                                style={styles.deleteButton}
+                                onPress={handleDeleteFriend}
+                                disabled={isDeleteFriend}
+                            >
+                                <Text style={styles.deleteButtonText}>
+                                    {isDeleteFriend ? "삭제 중" : "삭제"}
+                                </Text>
+                            </TouchableOpacity>
+
+                        </View>
+                    </View>
+                </View>
+
+            </Modal>
 
             {/*다른 사용자 여권 열람 바텀 시트*/}
             <FriendDetailModal
@@ -162,4 +235,62 @@ const styles = StyleSheet.create({
         fontSize: 13,
         fontWeight: "600",
     },
+    modalOverlay: {
+        flex: 1,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 24,
+    },
+    deleteModal: {
+        width: "100%",
+        backgroundColor: "#FFFFFF",
+        borderRadius: 20,
+        paddingHorizontal: 22,
+        paddingVertical: 24,
+        alignItems: "center",
+    },
+    deleteTitle: {
+        fontSize: 18,
+        fontWeight: "600",
+        color: "#111827",
+        marginBottom: 10,
+    },
+    deleteMessage: {
+        fontSize: 14,
+        color: "#6A7282",
+        textAlign: "center",
+        marginBottom: 24,
+    },
+    deleteButtonRow: {
+        width: "100%",
+        flexDirection: "row",
+        gap: 10,
+    },
+    cancelButton: {
+        flex: 1,
+        height: 44,
+        borderRadius: 12,
+        backgroundColor: "#E5E7EB",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    cancelButtonText: {
+        fontSize: 14,
+        fontWeight: "600",
+        color: "#374151",
+    },
+    deleteButton: {
+        flex: 1,
+        height: 44,
+        borderRadius: 12,
+        backgroundColor: "#EF4444",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    deleteButtonText: {
+        fontSize: 14,
+        fontWeight: "600",
+        color: "#FFFFFF"
+    }
 })

--- a/src/features/social/types/social.types.ts
+++ b/src/features/social/types/social.types.ts
@@ -32,3 +32,9 @@ export type RecommendedFriend = {
     stampCount?: number; // 도장 개수
     mutualFriends?: MutualFriend[]; // 함께 아는 친구
 }
+
+export type PublicUserProfile = {
+    userId: number;
+    nickname: string;
+    profileImg: string | null;
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #43 

## 📝 작업 내용
1. 친구 삭제 API 연결
2. 공개 프로필 조회 API 연결

### 친구 삭제
**<방식>**

- 친구 목록 화면인 `SocialView.tsx`에서 친구 삭제 대상 state와 삭제 확인 모달 상태를 관리하도록 구성
- `FriendCard.tsx`에 `onLongPress`를 추가해 친구 카드를 길게 눌렀을 때 삭제 확인 모달이 뜨도록 구현
- `FriendGrid.tsx`에서는 선택된 친구 정보를 `SocialView`로 전달해 삭제 대상 친구를 설정
- `삭제` 버튼을 누르면 `DELETE /api/v1/friends/{friendId}` API를 호출
- Swagger 형식에 맞게 path variable에는 `userId`나 `friendCode`가 아니라 Friend 테이블의 PK인 `friendId`를 전달
- API 응답이 성공하면 프론트의 `friends` state에서 해당 친구를 제거해 새로고침 없이 목록이 바로 갱신되도록 처리

### 공개 프로필 조회
**<방식>**

- 친구 추가 바텀시트인 `AddFriendModal.tsx`에서 추천 친구 카드 선택 시 공개 프로필 조회 API를 호출하도록 구성
- `AddFriendCard.tsx`에 `onPress`를 추가해 카드 자체를 눌렀을 때 선택한 사용자의 정보를 조회할 수 있도록 구현
- 사용자가 추천 친구 카드를 누르면 `handlePressFriendCard`가 실행되고, 선택한 친구의 `userId`를 이용해 `GET /api/v1/users/{userId}` API를 호출
- API 응답이 성공하면 응답으로 받은 `userId`, `nickname`, `profileImg`를 `selectedUser` state에 저장
- `selectedUser` 값이 존재하면 `PublicUserProfileModal`을 띄워 해당 사용자의 공개 프로필 정보를 표시하도록 처리


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

