### PR TITLE
feat: 여권 페이지 좋아요/스크랩 리스트 UI 변경 및 API 연결

### DIFF
--- a/src/features/passport/components/FavouriteList.tsx
+++ b/src/features/passport/components/FavouriteList.tsx
@@ -1,8 +1,9 @@
 // FavouriteList.tsx
-import React, { useState, useCallback } from 'react'
-import { View, Text, TouchableOpacity, FlatList } from 'react-native'
-import { passportStyles as styles } from './passportStyles'
+import { Ionicons } from '@expo/vector-icons'
 import { useFocusEffect } from 'expo-router'
+import React, { useCallback, useState } from 'react'
+import { FlatList, Image, Text, TouchableOpacity, View } from 'react-native'
+import { passportStyles as styles } from './passportStyles'
 
 type Props<T> = {
     fetchData: () => Promise<T[]>
@@ -11,15 +12,47 @@ type Props<T> = {
     onSelectPlace?: (item: T) => void
     renderName: (item: T) => string
     renderAddress: (item: T) => string
+    renderThumbnail?: (item: T) => string | null
+    renderContent?: (item: T) => string
+    renderDate?: (item: T) => string
+    dateLabel?:string
+    renderLikeCount?: (item: T) => number
+    renderScrapCount?: (item: T) => number
 }
 
-const FavouriteList = <T,>({ fetchData, keyExtractor, emptyText, onSelectPlace, renderName, renderAddress }: Props<T>) => {
+const formatDate = (dateString?: string) => {
+    if (!dateString) return ''
+
+    const date = new Date(dateString)
+    const year = date.getFullYear()
+    const month = String(date.getMonth() + 1).padStart(2, '0')
+    const day = String(date.getDate()).padStart(2, '0')
+
+    return `${year}.${month}.${day}`
+}
+
+const FavouriteList = <T,>({
+    fetchData,
+    keyExtractor,
+    emptyText,
+    onSelectPlace,
+    renderName,
+    renderAddress,
+    renderThumbnail,
+    renderContent,
+    renderDate,
+    dateLabel="저장일",
+    renderLikeCount,
+    renderScrapCount,
+}: Props<T>) => {
     const [items, setItems] = useState<T[]>([])
 
     useFocusEffect(
         useCallback(() => {
-            fetchData().then(setItems).catch(console.error)
-        }, [])
+            fetchData()
+                .then(setItems)
+                .catch(console.error)
+        }, [fetchData])
     )
 
     return (
@@ -28,21 +61,108 @@ const FavouriteList = <T,>({ fetchData, keyExtractor, emptyText, onSelectPlace, 
                 data={items}
                 keyExtractor={keyExtractor}
                 contentContainerStyle={styles.listContainer}
+                showsVerticalScrollIndicator={false}
                 ListEmptyComponent={
                     <View style={{ alignItems: 'center', marginTop: 60 }}>
-                        <Text style={{ color: '#aaa', fontSize: 15 }}>{emptyText}</Text>
+                        <Text style={{ color: '#aaa', fontSize: 15 }}>
+                            {emptyText}
+                        </Text>
                     </View>
                 }
-                renderItem={({ item }) => (
-                    <TouchableOpacity style={styles.listCard} onPress={() => onSelectPlace?.(item)}>
-                        <View style={styles.textArea}>
-                            <Text style={styles.listName}>{renderName(item)}</Text>
-                            <View style={styles.metaRow}>
-                                <Text style={styles.meta}>📍 {renderAddress(item)}</Text>
+                renderItem={({ item }) => {
+                    const thumbnailUrl = renderThumbnail?.(item)
+                    const dateText = renderDate ? formatDate(renderDate(item)) : ''
+
+                    return (
+                        <TouchableOpacity
+                            style={styles.listCard}
+                            onPress={() => onSelectPlace?.(item)}
+                            activeOpacity={0.85}
+                        >
+                            <View style={styles.thumbnailArea}>
+                                {thumbnailUrl ? (
+                                    <Image
+                                        source={{ uri: thumbnailUrl }}
+                                        style={styles.listThumbnail}
+                                    />
+                                ) : (
+                                    <View style={styles.listThumbnailPlaceholder}>
+                                        <Text style={styles.placeholderText}>
+                                            No Image
+                                        </Text>
+                                    </View>
+                                )}
+
+                                {dateText && (
+                                    <View style={styles.dateBadge}>
+                                        <Text style={styles.dateText}>
+                                            {dateLabel} {dateText}
+                                        </Text>
+                                    </View>
+                                )}
                             </View>
-                        </View>
-                    </TouchableOpacity>
-                )}
+
+                            <View style={styles.cardBody}>
+                                <View style={styles.placeTitleRow}>
+                                    <Ionicons
+                                        name="location"
+                                        size={20}
+                                        color="#1A3A6B"
+                                        style={styles.locationIcon}
+                                    />
+                                        <Text style={styles.listName} numberOfLines={1}>
+                                            {renderName(item)}
+                                        </Text>
+                                </View>
+
+                                <Text style={styles.meta} numberOfLines={1}>
+                                        {renderAddress(item)}
+                                </Text>
+
+                                {renderContent && (
+                                    <Text style={styles.contentText} numberOfLines={2}>
+                                        {renderContent(item)}
+                                    </Text>
+                                )}
+
+                                <View style={styles.divider} />
+
+                                <View style={styles.countRow}>
+                                    <View style={styles.countItem}>
+                                        <Ionicons
+                                            name="heart"
+                                            size={20}
+                                            color="#FF7A8A"
+                                        />
+
+                                        <Text style={styles.countText}>
+                                            {renderLikeCount ? renderLikeCount(item) : 0}
+                                        </Text>
+                                    </View>
+
+                                    <View style={styles.countItem}>
+                                        <Ionicons
+                                            name="bookmark"
+                                            size={20}
+                                            color="#1A3A6B"
+                                        />
+
+                                        <Text style={styles.countText}>
+                                            {renderScrapCount ? renderScrapCount(item) : 0}
+                                        </Text>
+                                    </View>
+
+                                    <Ionicons
+                                        name="chevron-forward"
+                                        size={22}
+                                        color="#9CA3AF"
+                                        style={styles.arrowIcon}
+                                    />
+                                </View>
+                            </View>
+                        </TouchableOpacity>
+                    )
+                }}
             />
         </View>
     )

--- a/src/features/passport/components/FavouriteList.tsx
+++ b/src/features/passport/components/FavouriteList.tsx
@@ -71,7 +71,9 @@ const FavouriteList = <T,>({
                 }
                 renderItem={({ item }) => {
                     const thumbnailUrl = renderThumbnail?.(item)
-                    const dateText = renderDate ? formatDate(renderDate(item)) : ''
+                    const rawDate = renderDate?.(item)
+                    const dateText = formatDate(rawDate)
+                    const contentText = renderContent?.(item) ?? ""
 
                     return (
                         <TouchableOpacity
@@ -93,7 +95,7 @@ const FavouriteList = <T,>({
                                     </View>
                                 )}
 
-                                {dateText && (
+                                {dateText.length > 0 && (
                                     <View style={styles.dateBadge}>
                                         <Text style={styles.dateText}>
                                             {dateLabel} {dateText}
@@ -119,9 +121,9 @@ const FavouriteList = <T,>({
                                         {renderAddress(item)}
                                 </Text>
 
-                                {renderContent && (
+                                {contentText.length > 0 && (
                                     <Text style={styles.contentText} numberOfLines={2}>
-                                        {renderContent(item)}
+                                        {contentText}
                                     </Text>
                                 )}
 

--- a/src/features/passport/components/LikeList.tsx
+++ b/src/features/passport/components/LikeList.tsx
@@ -9,6 +9,12 @@ const LikeList = ({ onSelectPlace }: { onSelectPlace?: (item: LikePassport) => v
         onSelectPlace={onSelectPlace}
         renderName={(item) => item.spaceName}
         renderAddress={(item) => item.address}
+        renderThumbnail={(item) => item.thumbnailUrl}
+        renderContent={(item) => item.content}
+        renderDate={(item) => item.likeCreatedAt}
+        dateLabel='저장일'
+        renderLikeCount={(item) => item.likeCount}
+        renderScrapCount={(item) => item.scrapCount}
     />
 )
 

--- a/src/features/passport/components/ScrapList.tsx
+++ b/src/features/passport/components/ScrapList.tsx
@@ -9,6 +9,12 @@ const ScrapList = ({ onSelectPlace }: { onSelectPlace?: (item: ScrapPassport) =>
         onSelectPlace={onSelectPlace}
         renderName={(item) => item.spaceName}
         renderAddress={(item) => item.address}
+        renderThumbnail={(item) => item.thumbnailUrl}
+        renderContent={(item) => item.content}
+        renderDate={(item) => item.scrapCreatedAt}
+        dateLabel='저장일'
+        renderLikeCount={(item) => item.likeCount}
+        renderScrapCount={(item) => item.scrapCount}
     />
 )
 

--- a/src/features/passport/components/passportStyles.ts
+++ b/src/features/passport/components/passportStyles.ts
@@ -1,4 +1,4 @@
-import { StyleSheet, Dimensions } from 'react-native'
+import { Dimensions, StyleSheet } from 'react-native'
 
 export const COVER_WIDTH = (Dimensions.get('window').width - 20 * 2 - 1) / 2
 export const COVER_HEIGHT = COVER_WIDTH * (4 / 3)
@@ -45,31 +45,28 @@ export const passportStyles = StyleSheet.create({
     },
     
     listContainer: {
-        paddingHorizontal: 16,
+        paddingHorizontal: 20,
         paddingBottom: 100,
     },
     
     listCard: {
-        width: Dimensions.get('window').width - 32,
-        height: 80,
-        flexDirection: 'row',
+        width: Dimensions.get('window').width - 40,
         backgroundColor: '#FFFFFF',
-        borderRadius: 16,
-        marginTop: 10,
-        marginBottom: 10,
-        alignItems: 'center',
-        shadowColor: '#1A3A6B',
-        shadowOffset: { width: 0, height: 0 },
-        shadowOpacity: 0.4,
-        shadowRadius: 5,
-        elevation: 4,
+        borderRadius: 18,
+        marginTop: 8,
+        marginBottom: 15,
+        overflow: "hidden",
+        shadowColor: '#4C4C4C',
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.16,
+        shadowRadius: 10,
+        elevation: 5,
     },
 
     listName: {
-        color: '#000000',
+        color: '#111827',
         fontSize: 18,
-        fontWeight: '600',
-        marginBottom: 4,
+        fontWeight: '700',
     },
     
     stamp: {
@@ -89,9 +86,9 @@ export const passportStyles = StyleSheet.create({
     },
 
     meta: { 
-        color: '#000000', 
-        fontSize: 14, 
-        fontWeight: '500' 
+        color: '#6B7280', 
+        fontSize: 13,
+        marginBottom: 10,
     },
 
     dropdown: {
@@ -117,4 +114,99 @@ export const passportStyles = StyleSheet.create({
         fontSize: 14, 
         color: '#000' 
     },
+
+    thumbnailArea: {
+        width: '100%',
+        height: 155,
+        backgroundColor: '#E5E7EB',
+        position: 'relative',
+    },
+    
+    listThumbnail: {
+        width: '100%',
+        height: '100%',
+        resizeMode: 'cover',
+    },
+    
+    listThumbnailPlaceholder: {
+        width: '100%',
+        height: '100%',
+        backgroundColor: '#EAEAEA',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    
+    placeholderText: {
+        fontSize: 13,
+        color: '#999',
+        fontWeight: '600',
+    },
+    
+    dateBadge: {
+        position: 'absolute',
+        top: 12,
+        right: 12,
+        backgroundColor: 'rgba(255, 255, 255, 0.92)',
+        borderRadius: 10,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+    },
+    
+    dateText: {
+        color: '#333333',
+        fontSize: 12,
+        fontWeight: '600',
+    },
+    
+    cardBody: {
+        paddingHorizontal: 22,
+        paddingTop: 18,
+        paddingBottom: 14,
+    },
+
+    placeTitleRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 6,    
+    },
+
+    locationIcon: {
+        marginRight: 8,
+    },
+
+    contentText: {
+        color: '#374151',
+        fontSize: 14,
+        lineHeight: 20,
+        marginBottom: 10,
+    },
+    
+    divider: {
+        height: 1,
+        backgroundColor: '#E5E7EB',
+        marginBottom: 10,
+    },
+    
+    countRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+    },
+    
+    countItem: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginRight: 18,
+    },
+    
+    countText: {
+        marginLeft: 8,
+        color: '#333333',
+        fontSize: 14,
+        fontWeight: '600',
+    },
+    
+    arrowIcon: {
+        marginLeft: 'auto',
+    },
+
 })


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.

## 📝 작업 내용
여권 페이지의 좋아요/스크랩 UI 수정 및 API 연결
**<방식>**

- 좋아요 목록과 스크랩 목록에서 공통으로 사용할 수 있도록 `FavouriteList.tsx`를 재사용 컴포넌트로 구성
- `FavouriteList`에서 `fetchData`, `keyExtractor`, `renderName`, `renderAddress`를 props로 받아 목록 데이터를 공통 렌더링하도록 구현
- 좋아요 목록인 `LikeList.tsx`에서는 `getMyLikes()` API를 호출하고, 스크랩 목록인 `ScrapList.tsx`에서는 `getMyScraps()` API를 호출
- `passportStyles.ts`에서 카드 스타일을 수정해 이미지, 장소명, 주소, 내용, 좋아요 수, 스크랩 수가 한 카드 안에 정렬되도록 구성
- 카드 클릭 시 `onSelectPlace`를 통해 선택된 좋아요/스크랩 항목을 부모 컴포넌트로 전달할 수 있도록 유지


## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

