### PR TITLE
feat: 팀 생성 및 팀 가입 API 연결

### DIFF
--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -1,13 +1,16 @@
 import * as Securestore from "expo-secure-store";
 import {
+    CreateTeamRequest,
     FriendRequestAction,
     FriendRequestActionRequest,
+    JoinTeamRequest,
     MyProfileResponse,
     PendingFriendResponse,
     PresignedUrlRequest,
     PresignedUrlResponse,
     ProfileEditForm,
     ProfileUser,
+    TeamResponseData,
     UpdateProfileRequest,
 } from "../features/profile/types/profile.types";
 import { BASE_URL } from "./config";
@@ -282,3 +285,61 @@ export const respondFriendRequest = async (
         throw new Error(errorMessage)
     }
 }
+
+// 9. 팀 생성
+export const createTeam = async (
+    teamName: string
+): Promise<TeamResponseData> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/teams`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+            teamName,
+        }satisfies CreateTeamRequest),
+    });
+
+    const result = await response.json();
+
+    console.log("팀 생성 상태:", response.status);
+    console.log("팀 생성 응답:", result);
+
+    if(!response.ok) {
+        throw new Error(result.message || "팀 생성 실패");
+    }
+
+    return result as TeamResponseData;
+};
+
+// 10. 팀 가입
+export const joinTeam = async (
+    teamCode: string
+): Promise<TeamResponseData> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/teams/join`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+            teamCode,
+        }satisfies JoinTeamRequest),
+    });
+
+    const result = await response.json();
+
+    console.log("팀 가입 상태:", response.status);
+    console.log("팀 가입 응답:", result);
+
+    if(!response.ok) {
+        throw new Error(result.message || "팀 가입 실패");
+    }
+
+    return result as TeamResponseData;
+};

--- a/src/features/profile/components/TeamManageModal.tsx
+++ b/src/features/profile/components/TeamManageModal.tsx
@@ -1,6 +1,9 @@
+import { createTeam, joinTeam } from "@/src/api/profileApi";
 import { Ionicons } from "@expo/vector-icons";
 import { useState } from "react";
 import {
+    ActivityIndicator,
+    Alert,
     Modal,
     Pressable,
     StyleSheet,
@@ -26,21 +29,61 @@ export default function TeamManageModal({
 
     const [teamName, setTeamName] = useState("");
     const [inviteCode, setInviteCode] = useState("");
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
     const isCreateMode = mode === "create";
 
-    const handleSubmit = () => {
-        if (isCreateMode) {
-            console.log("팀 생성:", {
-                teamName,
-            });
-            return;
-        }
+    // 팀 생성/팀 가입 호출
+    const handleSubmit = async () => {
+        if (isSubmitting) return;
 
-        console.log("팀 가입:", {
-            inviteCode,
-        })
+        try {
+            setIsSubmitting(true);
+
+            if(isCreateMode) {
+                const trimmedTeamName = teamName.trim();
+
+                const result = await createTeam(trimmedTeamName);
+
+                Alert.alert(
+                    "팀 생성 완료",
+                    `${result.teamName} 팀이 생성되었습니다.\n팀 코드: ${result.teamCode}`
+                );
+
+                setTeamName("");
+                onClose();
+                return;
+            }
+
+            const trimmedTeamCode = inviteCode.trim();
+
+            const result = await joinTeam(trimmedTeamCode);
+
+            Alert.alert(
+                "팀 가입 완료",
+                `${result.teamName} 팀에 가입되었습니다.`
+            )
+
+            setInviteCode("");
+            onClose();
+        } catch(error) {
+            console.log("팀 처리 에러:", error);
+
+            Alert.alert(
+                isCreateMode ? "팀 생성 실패" : "팀 가입 실패",
+                error instanceof Error
+                    ? error.message
+                    : "팀 처리 중 문제가 발생했습니다."
+            );
+        }finally {
+            setIsSubmitting(false);
+        }
     }
+
+
+    const isDisabled = isCreateMode
+        ? teamName.trim().length === 0 || isSubmitting
+        : inviteCode.trim().length === 0 || isSubmitting;
 
     return (
         <Modal
@@ -58,6 +101,7 @@ export default function TeamManageModal({
                             activeOpacity={0.8}
                             onPress={onClose}
                             style={styles.closeButton}
+                            disabled={isSubmitting}
                         >
                             <Ionicons name="close" size={22} color="#333333" />
                         </TouchableOpacity>
@@ -72,6 +116,7 @@ export default function TeamManageModal({
                                 isCreateMode && styles.activeTabButton,
                             ]}
                             onPress={() => setMode("create")}
+                            disabled={isSubmitting}
                         >
                             <Text
                                 style={[
@@ -91,6 +136,7 @@ export default function TeamManageModal({
                                 !isCreateMode && styles.activeTabButton,
                             ]}
                             onPress={() => setMode("join")}
+                            disabled={isSubmitting}
                         >
                             <Text
                                 style={[
@@ -114,6 +160,7 @@ export default function TeamManageModal({
                                     placeholderTextColor="#A0A0A0"
                                     value={teamName}
                                     onChangeText={setTeamName}
+                                    editable={!isSubmitting}
                                 />
                             </View>
 
@@ -121,12 +168,18 @@ export default function TeamManageModal({
                                 activeOpacity={0.8}
                                 style={[
                                     styles.submitButton,
-                                    teamName.trim().length === 0 && styles.disableButton,
+                                    isDisabled && styles.disableButton,
                                 ]}
                                 onPress={handleSubmit}
-                                disabled={teamName.trim().length === 0}
+                                disabled={isDisabled}
                             >
-                                <Text style={styles.submitButtonText}>팀 생성하기</Text>
+                                {isSubmitting ? (
+                                    <ActivityIndicator color="#FFFFFF" />
+                                ) : (
+                                    <Text style={styles.submitButtonText}>
+                                        팀 생성하기
+                                    </Text>
+                                )}
                             </TouchableOpacity>
                         </View>
                     ) : (
@@ -141,6 +194,7 @@ export default function TeamManageModal({
                                     value={inviteCode}
                                     onChangeText={setInviteCode}
                                     autoCapitalize="characters"
+                                    editable={!isSubmitting}
                                 />
                             </View>
 
@@ -152,12 +206,18 @@ export default function TeamManageModal({
                                 activeOpacity={0.8}
                                 style={[
                                     styles.submitButton,
-                                    inviteCode.trim().length === 0 && styles.disableButton,
+                                    isDisabled && styles.disableButton,
                                 ]}
                                 onPress={handleSubmit}
-                                disabled={inviteCode.trim().length === 0}
+                                disabled={isDisabled}
                             >
-                                <Text style={styles.submitButtonText}>팀 합류하기</Text>
+                                {isSubmitting ? (
+                                    <ActivityIndicator color="#FFFFFF" />
+                                ) : (
+                                    <Text style={styles.submitButtonText}>
+                                        팀 합류하기
+                                    </Text>
+                                )}
                             </TouchableOpacity>
 
                         </View>

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,6 +1,5 @@
 import { getMyProfile, logout } from "@/src/api/profileApi";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useFocusEffect, useRouter } from "expo-router";
 import * as Securestore from "expo-secure-store";
 import { useCallback, useState } from "react";
@@ -23,9 +22,10 @@ import {
 } from "../data/profileDummy";
 import { ProfileMenuItem, ProfileUser } from "../types/profile.types";
 
+const TAB_BAR_HEIGHT = 90;
+
 export default function ProfileView() {
     const router = useRouter();
-    const tabBarHeight = useBottomTabBarHeight();
 
     const [isTeam, setIsTeam] = useState(false);
     const [user, setUser] = useState<ProfileUser>(profileUserDummy);
@@ -154,7 +154,7 @@ export default function ProfileView() {
     
             {/* 스크롤 영역 */}
             <ScrollView
-                style={[styles.scrollArea, {marginBottom: tabBarHeight}]}
+                style={styles.scrollArea}
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
                 contentInsetAdjustmentBehavior="never"
@@ -299,10 +299,11 @@ const styles = StyleSheet.create({
     },
     scrollArea: {
         flex: 1,
+        marginBottom: TAB_BAR_HEIGHT,
     },
     scrollContent: {
         paddingHorizontal: 20,
-        paddingBottom:  50,
+        paddingBottom:  20,
     },
     sectionAccount: {
         marginBottom: 0,

--- a/src/features/profile/types/profile.types.ts
+++ b/src/features/profile/types/profile.types.ts
@@ -104,3 +104,21 @@ export type FriendRequestAction = "ACCEPT" | "REJECT";
 export type FriendRequestActionRequest = {
     action: FriendRequestAction;
 }
+
+// 팀 생성 요청
+export type CreateTeamRequest = {
+    teamName: string;
+};
+
+// 팀 가입 요청
+export type JoinTeamRequest = {
+    teamCode: string;
+};
+
+// 팀 생성/가입 응답 데이터
+export type TeamResponseData = {
+    teamId: number;
+    teamName: string;
+    teamCode: string;
+    createdAt: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #46 

## 📝 작업 내용
1. 팀 생성 API 연결 (`/api/v1/teams`)
2. 팀 가입 API 연결 (`/api/v1/teams/join`)

### 팀 생성
**<방식>**

- `profile.types.ts`에 팀 생성 요청 타입과 응답 타입을 추가
- `profileApi.ts`에 `createTeam` 함수를 만들고 `POST /api/v1/teams` API를 호출
- `TeamManageModal.tsx`에서 팀 생성 버튼을 `createTeam(teamName)` 호출로 변경
- API 호출 중에는 `isSubmitting` 상태를 사용해 버튼 중복 클릭을 막고, 로딩 표시가 뜨도록 처리
- 성공하면 팀 이름과 팀 코드를 `Alert`로 보여주고, 입력값을 초기화한 뒤 모달을 닫도록 함

### 팀 가입
**<방식>**

- `profile.types.ts`에 팀 가입 요청 타입을 추가
- `profileApi.ts`에 `joinTeam` 함수를 만들고 `POST /api/v1/teams/join` API를 호출하도록 연결
- `TeamManageModal.tsx`에서 팀 가입하기 탭일 때는 입력된 초대 코드를 `joinTeam(inviteCode)`에 전달하도록 분기 처리함
- API 호출 중에는 `isSubmitting`으로 버튼을 비활성화하고 로딩 인디케이터를 보여주도록 함
- 성공하면 가입한 팀 이름을 `Alert`로 보여주고, 초대 코드 입력값을 초기화한 뒤 모달을 닫도록 함

#### 참고사항
팀 가입은 아직 테스트하지 못 함 

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

