### PR TITLE
deploy: EAS APK 빌드 테스트

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,9 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": ["lightrip"],
+    "scheme": [
+      "lightrip"
+    ],
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
@@ -24,7 +26,10 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "package": "com.lightrip.LighTrip"
+      "package": "com.lightrip.LighTrip",
+      "permissions": [
+        "android.permission.RECORD_AUDIO"
+      ]
     },
     "web": {
       "bundler": "metro",
@@ -39,8 +44,11 @@
       [
         "@mj-studio/react-native-naver-map",
         {
-          "android": { "CLIENT_ID": "js0oliz8v9" },
-          "ios": { "CLIENT_ID": "js0oliz8v9" }
+          "client_id": "js0oliz8v9",
+          "android": {
+            "ACCESS_FINE_LOCATION": true,
+            "ACCESS_COARSE_LOCATION": true
+          }
         }
       ],
       [
@@ -49,10 +57,17 @@
           "cameraPermission": "사진 촬영을 위해 카메라 접근이 필요해요."
         }
       ],
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      "./plugin/withNaverMapMaven"
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "e7dd5638-9f0d-4f55-95ad-28014023f768"
+      }
     }
   }
 }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,24 @@
+{
+  "cli": {
+    "version": ">= 20.1.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/plugin/withNaverMapMaven.js
+++ b/plugin/withNaverMapMaven.js
@@ -1,0 +1,18 @@
+const { withProjectBuildGradle } = require("@expo/config-plugins");
+
+module.exports = function withNaverMapMaven(config) {
+  return withProjectBuildGradle(config, (config) => {
+    const contents = config.modResults.contents;
+
+    if (!contents.includes("repository.map.naver.com")) {
+      config.modResults.contents = contents.replace(
+        /allprojects\s*\{\s*repositories\s*\{/,
+        (match) =>
+          `${match}
+    maven { url 'https://repository.map.naver.com/archive/maven' }`
+      );
+    }
+
+    return config;
+  });
+};


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.

## 📝 작업 내용
**<방식>**
- React Native + Expo 프로젝트에서 테스트용 Android APK를 만들기 위해 `EAS Build`를 설정함
- `eas-cli`를 설치하고 `eas build:configure`로 EAS 프로젝트를 생성 및 연결함
- `eas.json`의 `preview` 프로필에 APK 빌드 설정을 추가함

```
"preview": {
  "distribution":"internal",
  "android": {
    "buildType":"apk"
  }
}
```
- 처음 빌드에서는 네이버 지도 SDK 의존성 문제로 Gradle 빌드가 실패함
- `android/build.gradle`에 네이버 지도 Maven 저장소가 이미 있는 것을 확인함
- 이후 APK 설치 시 `INSTALL_PARSE_FAILED_MANIFEST_MALFORMED` 오류가 발생했고, 원인은 네이버 지도 플러그인 설정에서 `CLIENT_ID` 값이 AndroidManifest에 제대로 들어가지 않은 문제로 확인함
- `app.json`의 네이버 지도 플러그인 설정을 문서 기준인 `client_id` 방식으로 수정함
- 수정 후 APK를 다시 빌드했고, PC에서 다운로드한 APK를 `adb install -r`로 설치해 `Success`가 뜨는 것을 확인함

**<제출 관련 정리>**
- 지금 만든 APK는 현재 코드 상태 기준이므로, 개발이 더 진행되면 최종 코드 기준으로 APK를 다시 빌드해야 함

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다.

