### PR TITLE
feat: 구별 랭킹 API 연결

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -125,3 +125,28 @@ export async function requestFriend(friendCode: string) {
     return data.data
 
 }
+
+// 4. 구 별 랭킹 조회 API 연결
+export async function getDistrictRanking (district: string) {
+    const token = await Securestore.getItemAsync("accessToken");
+
+    const url = `${BASE_URL}/api/v1/rankings/districts/${district}`;
+
+    const response = await fetch(url, {
+        method: "GET",
+        headers: {
+            Authorization: `Bearer ${token}`,
+        },
+    })
+
+    const data = await response.json();
+
+    console.log("구별 주간 랭킹 조회 상태 코드:", response.status);
+    console.log("구별 주간 랭킹 조회 응답:", data);
+
+    if(!response.ok || !data.success) {
+        throw new Error(data.message || "구별 랭킹 조회에 실패했습니다.");
+    }
+
+    return data.data;
+}

--- a/src/features/search/components/RankingContent.tsx
+++ b/src/features/search/components/RankingContent.tsx
@@ -1,31 +1,84 @@
-import { getTotalRanking } from "@/src/api/searchApi";
+import { getDistrictRanking, getTotalRanking } from "@/src/api/searchApi";
 import { useEffect, useState } from "react";
 import {
     ActivityIndicator,
     ScrollView,
     StyleSheet,
     Text,
-    View
+    TouchableOpacity,
+    View,
 } from "react-native";
+import type { RankingMode } from "../screens/searchScreen";
 import type { RankingUser } from "../types/ranking.types";
 import RankingItem from "./RankingItem";
 import TopRankingCard from "./TopRankingCard";
 
-export default function RankingContent() {
+type RankingContentProps = {
+    rankingMode: RankingMode;
+}
+
+type District = {
+    label: string;
+    value: string;
+};
+
+const DISTRICT: District[] = [
+    { label: "종로", value: "JONGNO" },
+    { label: "중구", value: "JUNG" },
+    { label: "용산", value: "YONGSAN" },
+    { label: "성동", value: "SEONGDONG" },
+    { label: "광진", value: "GWANGJIN" },
+    { label: "동대문", value: "DONGDAEMUN" },
+    { label: "중랑", value: "JUNGNANG" },
+    { label: "성북", value: "SEONGBUK" },
+    { label: "강북", value: "GANGBUK" },
+    { label: "도봉", value: "DOBONG" },
+    { label: "노원", value: "NOWON" },
+    { label: "은평", value: "EUNPYEONG" },
+    { label: "서대문", value: "SEODAEMUN" },
+    { label: "마포", value: "MAPO" },
+    { label: "양천", value: "YANGCHEON" },
+    { label: "강서", value: "GANGSEO" },
+    { label: "구로", value: "GURO" },
+    { label: "금천", value: "GEUMCHEON" },
+    { label: "영등포", value: "YEONGDEUNGPO" },
+    { label: "동작", value: "DONGJAK" },
+    { label: "관악", value: "GWANAK" },
+    { label: "서초", value: "SEOCHO" },
+    { label: "강남", value: "GANGNAM" },
+    { label: "송파", value: "SONGPA" },
+    { label: "강동", value: "GANGDONG" }, 
+]
+
+export default function RankingContent({rankingMode}: RankingContentProps) {
     const [rankingList, setRankingList] = useState<RankingUser[]>([]);
     const [myRank, setMyRank] = useState<RankingUser | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState("");
+    const [selectedDistrict, setSelectedDistrict] = useState("JONGNO");
 
+    const selectedDistrictLabel =
+        DISTRICT.find((district) => district.value === selectedDistrict)?.label ?? "종로";
+
+    //랭킹 화면 호출
     const fetchRanking = async () => {
         try {
             setIsLoading(true);
             setErrorMessage("");
 
-            const result = await getTotalRanking();
+            // 이번 주 랭킹 호출
+            if (rankingMode === "total") {
+                const result = await getTotalRanking();
 
-            setRankingList(result.topRankings);
-            setMyRank(result.myRank);
+                setRankingList(result.topRankings);
+                setMyRank(result.myRank);
+            // 구별 랭킹 호출
+            }else {
+                const result = await getDistrictRanking(selectedDistrict);
+
+                setRankingList(result);
+                setMyRank(null);
+            }
         }catch(error) {
             console.log("랭킹 조회 에러:", error);
 
@@ -41,7 +94,9 @@ export default function RankingContent() {
 
     useEffect(() => {
         fetchRanking();
-    }, []);
+    }, [rankingMode, selectedDistrict]);
+
+    const topThree = rankingList.slice(0, 3);
 
     if (isLoading) {
         return (
@@ -67,36 +122,123 @@ export default function RankingContent() {
         )
     }
 
-    const topThree = rankingList.slice(0, 3);
-
     return (
-        <ScrollView
-            contentContainerStyle={styles.scrollContent}
-            showsVerticalScrollIndicator={false}
-        >
-            <View style={styles.topRankingRow}>
-                {topThree.map((user) => (
-                    <TopRankingCard key={user.userId} user={user} />
-                ))}
-            </View>
+        <View style={styles.container}>
+            {rankingMode === "district" && (
+                <>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={styles.districtScrollContent}
+                    >
+                        {DISTRICT.map((district) => (
+                            <TouchableOpacity
+                                key={district.value}
+                                style={[
+                                    styles.districtChip,
+                                    selectedDistrict === district.value &&
+                                        styles.activeDistrictChip,
+                                ]}
+                                onPress={() => setSelectedDistrict(district.value)}
+                            >
+                                <Text
+                                    style={[
+                                        styles.districtText,
+                                        selectedDistrict === district.value &&
+                                            styles.activeDistrictText,
+                                    ]}
+                                >
+                                    {district.label}
+                                </Text>
+                            </TouchableOpacity>
+                        ))}
+                    </ScrollView>
 
-            {myRank && (
-                <View style={styles.myRankBox}>
-                    <Text style={styles.myRankTitle}>내 랭킹</Text>
-                    <RankingItem user={myRank} isMyRank />
-                </View>
+                    <Text style={styles.districtTitle}>
+                        {selectedDistrictLabel} 랭킹
+                    </Text>
+                </>
             )}
 
-            <View style={styles.rankingList}>
-                {rankingList.map((user) => (
-                    <RankingItem key={user.userId} user={user} />
-                ))}
-            </View>
-        </ScrollView>
+            {isLoading ? (
+                <View style={styles.centerBox}>
+                    <ActivityIndicator size="large" color="#1A3A6B" />
+                </View>
+            ) : errorMessage ? (
+                <View style={styles.centerBox}>
+                    <Text style={styles.errorText}>{errorMessage}</Text>
+                </View>
+            ) : rankingList.length === 0 ? (
+                <View style={styles.centerBox}>
+                    <Text style={styles.emptyText}>
+                        아직 랭킹 데이터가 없습니다.
+                    </Text>
+                </View>
+            ) : (
+                <ScrollView
+                    contentContainerStyle={styles.scrollContent}
+                    showsVerticalScrollIndicator={false}
+                >
+                    <View style={styles.topRankingRow}>
+                        {topThree.map((user) => (
+                            <TopRankingCard key={user.userId} user={user} />
+                        ))}
+                    </View>
+
+                    {rankingMode === "total" && myRank && (
+                        <View style={styles.myRankBox}>
+                            <Text style={styles.myRankTitle}>내 랭킹</Text>
+                            <RankingItem user={myRank} isMyRank />
+                        </View>
+                    )}
+
+                    <View style={styles.rankingList}>
+                        {rankingList.map((user) => (
+                            <RankingItem key={user.userId} user={user} />
+                        ))}
+                    </View>
+                </ScrollView>
+            )}
+        </View>
     )
 }
 
 const styles =StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    districtScrollContent: {
+        paddingHorizontal: 20,
+        paddingBottom: 10,
+        gap: 8,
+    },
+    districtChip: {
+        minWidth: 55,
+        height: 34,
+        paddingHorizontal: 14,
+        borderRadius: 18,
+        backgroundColor: "#E5EAF3",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    activeDistrictChip: {
+        backgroundColor: "#1A3A6B",
+    },
+    districtText: {
+        fontSize: 13,
+        fontWeight: "600",
+        color: "#4B5563",
+        textAlign: "center",
+    },
+    activeDistrictText: {
+        color: "#FFFFFF",
+    },
+    districtTitle: {
+        paddingHorizontal: 20,
+        fontSize: 16,
+        fontWeight: "700",
+        color: "#1A3A6B",
+    },
     scrollContent: {
         paddingHorizontal: 20,
         paddingTop: 2,
@@ -121,7 +263,7 @@ const styles =StyleSheet.create({
     topRankingRow: {
         flexDirection: "row",
         justifyContent: "space-between",
-        alignItems: "flex-end",
+        alignItems: "center",
         marginBottom: 18,
     },
     myRankBox: {
@@ -135,5 +277,5 @@ const styles =StyleSheet.create({
     },
     rankingList: {
         gap: 12,
-    }
+    },
 })

--- a/src/features/search/components/RankingItem.tsx
+++ b/src/features/search/components/RankingItem.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Image, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import type { RankingUser } from "../types/ranking.types";
 
 type RankingItemProps = {
@@ -13,15 +13,6 @@ export default function RankingItem({ user, isMyRank = false }: RankingItemProps
             <View style={styles.rankCircle}>
                 <Text style={styles.rankText}>{user.rank}</Text>
             </View>
-
-            <Image
-                source={
-                    user.profileImageUrl
-                        ? { uri: user.profileImageUrl }
-                        : require("@/assets/images/default_profile.png")
-                }
-                style={styles.rankingProfileImage}
-            />
 
             <View style={styles.rankingUserInfo}>
                 <Text style={styles.rankingName} numberOfLines={1}>
@@ -85,17 +76,9 @@ const styles = StyleSheet.create({
         fontWeight: "600",
         color: "#FFFFFF",
     },
-    rankingProfileImage: {
-        width: 50,
-        height: 50,
-        borderRadius: 25,
-        backgroundColor: "#d9d9d9",
-        borderWidth: 2,
-        borderColor: "#1A3A6B",
-        marginRight: 12,
-    },
     rankingUserInfo: {
         flex: 1,
+        marginLeft: 10,
     },
     rankingName: {
         fontSize: 16,

--- a/src/features/search/components/TopRankingCard.tsx
+++ b/src/features/search/components/TopRankingCard.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Image, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import type { RankingUser } from "../types/ranking.types";
 
 type TopRankingCardProps = {
@@ -7,25 +7,9 @@ type TopRankingCardProps = {
 };
 
 export default function TopRankingCard({ user }: TopRankingCardProps) {
-
-    const isFristRank = user.rank === 1;
-
     return (
-        <View 
-            style={[
-                styles.topRankingCard,
-                isFristRank && styles.firstRankingCard,
-            ]}
-        >
+        <View style={styles.topRankingCard}>
             <Text style={styles.medalText}>{getMedal(user.rank)}</Text>
-            <Image
-                source={
-                    user.profileImageUrl
-                        ? {uri : user.profileImageUrl}
-                        : require("@/assets/images/default_profile.png")
-                }
-                style={styles.profileImage}
-            />
             <Text style={styles.topRankingName} numberOfLines={1}>
                 {user.nickname}
             </Text>
@@ -48,34 +32,24 @@ function getMedal(rank: number) {
 const styles = StyleSheet.create({
     topRankingCard: {
         width: "31%",
-        height: 132,
+        height: 120,
         backgroundColor: "#1A3A6B",
         borderRadius: 15,
         alignItems: "center",
         justifyContent: "center",
-        paddingHorizontal: 6,
-    },
-    firstRankingCard: {
-        height: 154,
+        paddingHorizontal: 8,
     },
     medalText: {
-        fontSize: 20,
-        marginBottom: 4,
-    },
-    profileImage: {
-        width: 45,
-        height: 45,
-        borderRadius: 21,
-        backgroundColor: "#d9d9d9",
-        borderWidth: 2,
-        borderColor: "#FFFFFF",
-        marginBottom: 6,
+        fontSize: 24,
+        marginBottom: 10,
     },
     topRankingName: {
-        fontSize: 16,
+        fontSize: 15,
         fontWeight: "600",
         color: "#FFFFFF",
-        marginBottom: 2,
+        marginBottom: 6,
+        textAlign: "center",
+        maxWidth: "100%",
     },
     scoreRow: {
         flexDirection: "row",

--- a/src/features/search/screens/searchScreen.tsx
+++ b/src/features/search/screens/searchScreen.tsx
@@ -1,26 +1,101 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import AllSearchContent from "../components/AllSearchContent";
 import RankingContent from "../components/RankingContent";
 import SearchToggle from "../components/SearchToggle";
 import { SearchTab } from "../types/search.types";
 
+export type RankingMode = "total" | "district";
+
 export default function SearchView() {
     const [selectedTab, setSelectedTab] = useState<SearchTab>("all");
     const [requestedFriendCodes, setRequestedFriendCodes] = useState<string[]>([]);
 
+    // total & district 선택
+    const [rankingMode, setRankingMode] = useState<RankingMode>("total");
+    const [isRankingDropdownOpen, setIsRankingDropdownOpen] = useState(false);
+
+    const rankingTitle = 
+        rankingMode === "total" ? "이번 주 랭킹" : "구별 랭킹";
+
+    const handleSelectRankingMode = (mode: RankingMode) => {
+        setRankingMode(mode);
+        setIsRankingDropdownOpen(false);
+    };
 
     return (
         <SafeAreaView style={styles.container}>
             <View style={styles.header}>
-                <Text style={styles.title}>
-                    {selectedTab === "all" ? "둘러보기" : "이번 주 랭킹"}
-                </Text>
+                {selectedTab === 'all' ? (
+                    <Text style={styles.title}>둘러보기</Text>
+                ) : (
+                    <View style={styles.rankingTitleWrapper}>
+                        <TouchableOpacity
+                            style={styles.rankingTitleButton}
+                            activeOpacity={0.8}
+                            onPress={() => setIsRankingDropdownOpen((prev) => !prev)}
+                        >
+                            <Text style={styles.title}>{rankingTitle}</Text>
+                            <Ionicons
+                                name={
+                                    isRankingDropdownOpen
+                                        ? "caret-up"
+                                        : "caret-down"
+                                }
+                                size={16}
+                                color="#000000"
+                            />
+                        </TouchableOpacity>
 
+                        {/*토글*/}
+                        {isRankingDropdownOpen && (
+                            <View style={styles.dropdownBox}>
+                                <TouchableOpacity
+                                    style={styles.dropdownItem}
+                                    onPress={() =>
+                                        handleSelectRankingMode("total")
+                                    }
+                                >
+                                    <Text
+                                        style={[
+                                            styles.dropdownText,
+                                            rankingMode === "total" &&
+                                                styles.activeDropdownText,
+                                        ]}
+                                    >
+                                        이번 주 랭킹
+                                    </Text>
+                                </TouchableOpacity>
+
+                                <TouchableOpacity
+                                    style={styles.dropdownItem}
+                                    onPress={() =>
+                                        handleSelectRankingMode("district")
+                                    }
+                                >
+                                    <Text
+                                        style={[
+                                            styles.dropdownText,
+                                            rankingMode === "district" &&
+                                                styles.activeDropdownText,
+                                        ]}
+                                    >
+                                        구별 랭킹
+                                    </Text>
+                                </TouchableOpacity>
+                            </View>
+                        )}
+                    </View>
+                )}
+                
                 <SearchToggle
                     selectedTab={selectedTab}
-                    onChangeTab={setSelectedTab}
+                    onChangeTab={(tab) => {
+                        setSelectedTab(tab);
+                        setIsRankingDropdownOpen(false);
+                    }}
                 />
             </View>
 
@@ -30,7 +105,7 @@ export default function SearchView() {
                     setRequestedFriendCodes={setRequestedFriendCodes}
                 />
             ) : (
-                <RankingContent />
+                <RankingContent rankingMode={rankingMode} />
             )}
         </SafeAreaView>
     );
@@ -40,6 +115,7 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         backgroundColor: "#F8FAFD",
+        overflow: "visible",
     },
     header: {
         flexDirection: "row",
@@ -48,10 +124,49 @@ const styles = StyleSheet.create({
         marginBottom: 20,
         paddingHorizontal: 20,
         paddingTop: 22,
+        zIndex: 100,
+        elevation: 100,
+    },
+    rankingTitleWrapper: {
+        position: "relative",
+        zIndex: 200,
+        elevation: 200,
     },
     title: {
         fontWeight: "700",
         color: "#000000",
         fontSize: 24,
     },
-});
+    rankingTitleButton: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 6,
+    },
+    dropdownBox: {
+        position: "absolute",
+        top: 34,
+        left: 0,
+        width: 130,
+        backgroundColor: "#FFFFFF",
+        borderRadius: 12,
+        paddingVertical: 6,
+        shadowColor: "#000",
+        shadowOpacity: 0.14,
+        shadowRadius: 8,
+        elevation: 300,
+        zIndex: 300,
+    },
+    dropdownItem: {
+        paddingVertical: 10,
+        paddingHorizontal: 14,
+    },
+    dropdownText: {
+        fontSize: 14,
+        fontWeight: "600",
+        color: "#666667",
+    },
+    activeDropdownText: {
+        color: "#1A3A6B",
+        fontWeight: "700",
+    },
+})

--- a/src/features/search/types/search.types.ts
+++ b/src/features/search/types/search.types.ts
@@ -1,1 +1,3 @@
 export type SearchTab = "all" | "ranking";
+
+export type RankingTab = "total" | "district";

--- a/src/features/social/data/districtCoords.ts
+++ b/src/features/social/data/districtCoords.ts
@@ -1,0 +1,107 @@
+export type DistrictCoord = {
+    latitude: number;
+    longitude: number;
+};
+
+export const DISTRICT_COORDS: Record<string, DistrictCoord> = {
+    JONGNO: {
+        latitude: 37.5735,
+        longitude: 126.9788,
+    },
+    MAPO: {
+        latitude: 37.5663,
+        longitude: 126.9019,
+    },
+    JUNG: {
+        latitude: 37.5636,
+        longitude: 126.9976,
+    },
+    GANGNAM: {
+        latitude: 37.5172,
+        longitude: 127.0473,
+    },
+    SEOCHO: {
+        latitude: 37.4837,
+        longitude: 127.0324,
+    },
+    SONGPA: {
+        latitude: 37.5145,
+        longitude: 127.1059,
+    },
+    YONGSAN: {
+        latitude: 37.5326,
+        longitude: 126.9900,
+    },
+    SEONGDONG: {
+        latitude: 37.5633,
+        longitude: 127.0369,
+    },
+    GWANGJIN: {
+        latitude: 37.5384,
+        longitude: 127.0823,
+    },
+    DONGDAEMUN: {
+        latitude: 37.5744,
+        longitude: 127.0396,
+    },
+    JUNGNANG: {
+        latitude: 37.6063,
+        longitude: 127.0925,
+    },
+    SEONGBUK: {
+        latitude: 37.5894,
+        longitude: 127.0167,
+    },
+    GANGBUK: {
+        latitude: 37.6396,
+        longitude: 127.0257,
+    },
+    DOBONG: {
+        latitude: 37.6688,
+        longitude: 127.0471,
+    },
+    NOWON: {
+        latitude: 37.6542,
+        longitude: 127.0568,
+    },
+    EUNPYEONG: {
+        latitude: 37.6176,
+        longitude: 126.9227,
+    },
+    SEODAEMUN: {
+        latitude: 37.5791,
+        longitude: 126.9368,
+    },
+    YANGCHEON: {
+        latitude: 37.5169,
+        longitude: 126.8664,
+    },
+    GANGSEO: {
+        latitude: 37.5509,
+        longitude: 126.8495,
+    },
+    GURO: {
+        latitude: 37.4955,
+        longitude: 126.8877,
+    },
+    GEUMCHEON: {
+        latitude: 37.4569,
+        longitude: 126.8955,
+    },
+    YEONGDEUNGPO: {
+        latitude: 37.5264,
+        longitude: 126.8962,
+    },
+    DONGJAK: {
+        latitude: 37.5124,
+        longitude: 126.9393,
+    },
+    GWANAK: {
+        latitude: 37.4784,
+        longitude: 126.9516,
+    },
+    GANGDONG: {
+        latitude: 37.5301,
+        longitude: 127.1238,
+    },
+};


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.

## 📝 작업 내용
구별 랭킹 기능 추가
- 상단의 “이번 주 랭킹” 제목 옆 드롭다운으로 “이번 주 랭킹”과 “구별 랭킹”을 선택
- 선택된 값은 `rankingMode` 상태로 관리

- 구별 랭킹을 선택했을 때는 서울의 각 구를 가로 스크롤 칩 형태로 보여줌
- 사용자가 특정 구를 선택하면 `selectedDistrict` 상태가 변경되도록 구성
- 이후 `rankingMode`와 `selectedDistrict` 값을 기준으로 API 호출 방식을 분기
-  전체 랭킹일 때는 기존의 `getTotalRanking()`을 호출하고 구별 랭킹일 때는 `getDistrictRanking(selectedDistrict)`를 호출하도록 연결

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

