### PR TITLE
feat: 팀 페이지 UI 구현 및 API 연결

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,10 +1,13 @@
-// app/(tabs)/_layout.tsx
+import { TeamModeProvider, useTeamMode } from "@/src/components/common/TeamModeContext";
 import colors from "@/src/constant/colors";
 import { Ionicons } from "@expo/vector-icons";
-import { Tabs } from "expo-router";
+import { Tabs, useRouter } from "expo-router";
 import { View } from "react-native";
 
-export default function TabLayout() {
+function TabsLayoutContent() {
+  const router = useRouter();
+  const { isTeamMode } = useTeamMode();
+
   return (
     <Tabs
       screenOptions={{
@@ -36,6 +39,7 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="profile"
         options={{
@@ -46,6 +50,7 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="index"
         options={{
@@ -67,6 +72,7 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="social"
         options={{
@@ -77,16 +83,44 @@ export default function TabLayout() {
           ),
         }}
       />
+
       <Tabs.Screen
         name="search"
         options={{
-          title: "둘러보기",
+          title: isTeamMode ? "팀" : "둘러보기",
           tabBarItemStyle: { marginTop: 10 },
           tabBarIcon: ({ color }) => (
-            <Ionicons name="search" size={24} color={color} />
+            <Ionicons
+              name={isTeamMode ? "people-circle" : "search"}
+              size={24}
+              color={color}
+            />
           ),
+        }}
+        listeners={{
+          tabPress: (e) => {
+            if (isTeamMode) {
+              e.preventDefault();
+              router.push("/team");
+            }
+          },
+        }}
+      />
+
+      <Tabs.Screen
+        name="team"
+        options={{
+          href: null,
         }}
       />
     </Tabs>
+  );
+}
+
+export default function TabLayout() {
+  return (
+    <TeamModeProvider>
+      <TabsLayoutContent />
+    </TeamModeProvider>
   );
 }

--- a/app/(tabs)/team.tsx
+++ b/app/(tabs)/team.tsx
@@ -1,0 +1,5 @@
+import TeamView from "@/src/features/team/screens/TeamScreen";
+
+export default function TeamScreen() {
+  return <TeamView />;
+}

--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -313,7 +313,13 @@ export const createTeam = async (
         throw new Error(result.message || "팀 생성 실패");
     }
 
-    return result as TeamResponseData;
+    const teamData = result as TeamResponseData;
+
+    await Securestore.setItemAsync("teamId", String(teamData.teamId));
+    await Securestore.setItemAsync("teamCode", teamData.teamCode);
+    await Securestore.setItemAsync("teamName", teamData.teamName);
+
+    return teamData;
 };
 
 // 10. 팀 가입
@@ -342,5 +348,11 @@ export const joinTeam = async (
         throw new Error(result.message || "팀 가입 실패");
     }
 
-    return result as TeamResponseData;
+    const teamData = result as TeamResponseData;
+
+    await Securestore.setItemAsync("teamId", String(teamData.teamId));
+    await Securestore.setItemAsync("teamCode", teamData.teamCode);
+    await Securestore.setItemAsync("teamName", teamData.teamName);
+
+    return teamData;
 };

--- a/src/api/teamApi.ts
+++ b/src/api/teamApi.ts
@@ -1,0 +1,129 @@
+import type { TeamInfo, TeamLiveLocation, TeamMember } from "@/src/features/team/types/team.types";
+import * as Securestore from "expo-secure-store";
+import { BASE_URL } from "./config";
+
+// 로그인 토큰 얻기
+const getAccessToken = async () => {
+    const accessToken = await Securestore.getItemAsync("accessToken");
+
+    if (!accessToken) {
+        throw new Error("로그인 토큰이 없습니다.");
+    }
+
+    return accessToken;
+};
+
+// 1. 팀 기본 정보 조회 API
+export const getTeamInfo = async (
+    teamId: number
+): Promise<TeamInfo> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/teams/${teamId}`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    const result = await response.json();
+
+    console.log("팀 정보 조회 상태:", response.status);
+    console.log("팀 정보 조회 응답:", result);
+
+    if (!response.ok) {
+        throw new Error(result.message || "팀 정보 조회 실패");
+    }
+
+    return result as TeamInfo;
+};
+
+// 2. 팀 탈퇴
+export const leaveTeam = async (
+    teamId: number
+): Promise<void> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/teams/${teamId}/members/me`, {
+        method: "DELETE",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    console.log("팀 탈퇴 상태:", response.status);
+
+    if (!response.ok) {
+        let errorMessage = "팀 탈퇴 실패";
+
+        try {
+            const result = await response.json();
+            console.log("팀 탈퇴 에러 응답:", result);
+            errorMessage = result.message || errorMessage;
+        } catch {
+            console.log("팀 탈퇴 응답 body 없음");
+        }
+
+        throw new Error(errorMessage);
+    }
+
+    await Securestore.deleteItemAsync("teamId");
+    await Securestore.deleteItemAsync("teamCode");
+    await Securestore.deleteItemAsync("teamName");
+};
+
+// 3. 팀 멤버 목록 조회
+export const getTeamMembers = async (
+    teamId: number
+): Promise<TeamMember[]> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(`${BASE_URL}/api/v1/teams/${teamId}/members`, {
+        method: "GET",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${accessToken}`,
+        },
+    });
+
+    const result = await response.json();
+
+    console.log("팀 멤버 목록 조회 상태:", response.status);
+    console.log("팀 멤버 목록 조회 응답:", result);
+
+    if (!response.ok) {
+        throw new Error(result.message || "팀 멤버 목록 조회 실패");
+    }
+
+    return result as TeamMember[];
+};
+
+// 4. 팀 실시간 위치 조회 
+export const getTeamLiveLocations = async (
+    teamId: number
+): Promise<TeamLiveLocation[]> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(
+        `${BASE_URL}/api/v1/teams/${teamId}/live-locations`,
+        {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${accessToken}`,
+            },
+        }
+    );
+
+    const result = await response.json();
+
+    console.log("팀 실시간 위치 조회 상태:", response.status);
+    console.log("팀 실시간 위치 조회 응답:", result);
+
+    if (!response.ok) {
+        throw new Error(result.message || "팀 실시간 위치 조회 실패");
+    }
+
+    return result as TeamLiveLocation[];
+};

--- a/src/components/common/TeamModeContext.tsx
+++ b/src/components/common/TeamModeContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, ReactNode, useContext, useState } from "react";
+
+type TeamModeContextType = {
+    isTeamMode: boolean;
+    setIsTeamMode: (value: boolean) => void;
+    toggleTeamMode: () => void;
+};
+
+const TeamModeContext = createContext<TeamModeContextType | null>(null);
+
+export function TeamModeProvider({ children }: { children: ReactNode }) {
+    const [isTeamMode, setIsTeamMode] = useState(false);
+
+    const toggleTeamMode = () => {
+    setIsTeamMode((prev) => !prev);
+    };
+
+    return (
+        <TeamModeContext.Provider
+        value={{
+            isTeamMode,
+            setIsTeamMode,
+            toggleTeamMode,
+        }}
+        >
+        {children}
+        </TeamModeContext.Provider>
+    );
+}
+
+export function useTeamMode() {
+    const context = useContext(TeamModeContext);
+
+    if (!context) {
+        throw new Error("useTeamMode must be used within TeamModeProvider");
+    }
+
+    return context;
+}

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,4 +1,5 @@
 import { getMyProfile, logout } from "@/src/api/profileApi";
+import { useTeamMode } from "@/src/components/common/TeamModeContext";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
 import * as Securestore from "expo-secure-store";
@@ -27,7 +28,7 @@ const TAB_BAR_HEIGHT = 90;
 export default function ProfileView() {
     const router = useRouter();
 
-    const [isTeam, setIsTeam] = useState(false);
+    const { isTeamMode, setIsTeamMode } = useTeamMode();
     const [user, setUser] = useState<ProfileUser>(profileUserDummy);
     const [isLoading, setIsLoading] = useState(true);
 
@@ -188,7 +189,7 @@ export default function ProfileView() {
                                 <View>
                                     <Text style={styles.menuTitle}>팀으로 전환</Text>
                                     <Text style={styles.menuDescription}>
-                                        현재 접속 모드: {isTeam ? "팀" : "개인"}
+                                        현재 접속 모드: {isTeamMode ? "팀" : "개인"}
                                     </Text>
                                 </View>
                             </View>
@@ -197,14 +198,14 @@ export default function ProfileView() {
                                 activeOpacity={0.8}
                                 style={[
                                     styles.teamToggle,
-                                    isTeam ? styles.teamToggleOn : styles.teamToggleOff,
+                                    isTeamMode ? styles.teamToggleOn : styles.teamToggleOff,
                                 ]}
-                                onPress={() => setIsTeam(!isTeam)}
+                                onPress={() => setIsTeamMode(!isTeamMode)}
                             >
                                 <View
                                     style={[
                                         styles.teamToggleCircle,
-                                        isTeam ? styles.teamToggleCircleOn : styles.teamToggleCircleOff,
+                                        isTeamMode ? styles.teamToggleCircleOn : styles.teamToggleCircleOff,
                                     ]}
                                 />
                             </TouchableOpacity>

--- a/src/features/team/screens/TeamScreen.tsx
+++ b/src/features/team/screens/TeamScreen.tsx
@@ -1,0 +1,614 @@
+import { getTeamInfo, getTeamLiveLocations, getTeamMembers, leaveTeam } from "@/src/api/teamApi";
+import { useEffect, useState } from "react";
+import {
+    ActivityIndicator,
+    Alert,
+    Image,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from "react-native";
+import type { TeamInfo, TeamLiveLocation, TeamMember } from "../types/team.types";
+
+export default function TeamView() {
+
+    const [team, setTeam] = useState<TeamInfo | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    // 팀원
+    const [members, setMembers] = useState<TeamMember[]>([]);
+    const [isMemberOpen, setIsMemberOpen] = useState(false);
+    const [isMemberLoading, setIsMemberLoading] = useState(false);
+
+    // 실시간 위치
+    const [liveLocations, setLiveLocations] = useState<TeamLiveLocation[]>([]);
+    const [isLocationOpen, setIsLocationOpen] = useState(false);
+    const [isLocationLoading, setIsLocationLoading] = useState(false);
+
+    // 1. 팀 정보 조회 호출
+    const fetchTeamInfo = async () => {
+        try {
+        setIsLoading(true);
+
+        // 테스트 팀 Id
+        const teamId = 26;
+
+        /*const savedTeamId = await Securestore.getItemAsync("teamId");
+        const savedTeamCode = await Securestore.getItemAsync("teamCode");
+        const savedTeamName = await Securestore.getItemAsync("teamName");
+
+        console.log("저장된 teamId:", savedTeamId);
+        console.log("저장된 teamCode:", savedTeamCode);
+        console.log("저장된 teamName:", savedTeamName);
+
+        if (!savedTeamId) {
+            setTeam(null);
+            return;
+        }
+
+        const data = await getTeamInfo(Number(savedTeamId));
+        */
+
+        const teamData = await getTeamInfo(teamId);
+        setTeam(teamData);
+        } catch (error) {
+            console.error("팀 정보 조회 실패:", error);
+            Alert.alert("오류", "팀 정보를 불러오지 못했습니다.");
+        } finally {
+        setIsLoading(false);
+        }
+    };
+
+    // 2. 팀 탈퇴 호출
+    const handleLeaveTeam = () => {
+        if (!team) return;
+    
+        Alert.alert(
+            "팀 탈퇴",
+            "정말로 팀에서 탈퇴하시겠어요?",
+            [
+                {
+                    text: "취소",
+                    style: "cancel",
+                },
+                {
+                    text: "탈퇴하기",
+                    style: "destructive",
+                    onPress: async () => {
+                        try {
+                            await leaveTeam(team.teamId);
+    
+                            Alert.alert("완료", "팀에서 탈퇴했습니다.");
+                            setTeam(null);
+                        } catch (error) {
+                            console.error("팀 탈퇴 실패:", error);
+    
+                            Alert.alert(
+                                "탈퇴 실패",
+                                error instanceof Error
+                                    ? error.message
+                                    : "팀 탈퇴에 실패했습니다."
+                            );
+                        }
+                    },
+                },
+            ]
+        );
+    };
+
+    // 3. 팀원 목록 조회 호출
+    const handlePressMembers = async () => {
+        if (!team) return;
+    
+        // 이미 열려 있으면 닫기
+        if (isMemberOpen) {
+            setIsMemberOpen(false);
+            return;
+        }
+    
+        try {
+            setIsMemberLoading(true);
+    
+            const memberData = await getTeamMembers(team.teamId);
+            setMembers(memberData);
+            setIsMemberOpen(true);
+        } catch (error) {
+            console.error("팀 멤버 목록 조회 실패:", error);
+            Alert.alert("오류", "팀원 목록을 불러오지 못했습니다.");
+        } finally {
+            setIsMemberLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        fetchTeamInfo();
+    }, []);
+
+    if (isLoading) {
+        return (
+        <View style={styles.centerContainer}>
+            <ActivityIndicator size="large" />
+            <Text style={styles.loadingText}>팀 정보를 불러오는 중...</Text>
+        </View>
+        );
+    }
+
+    // 4. 실시간 위치 호출
+    const handlePressLiveLocations = async () => {
+        if (!team) return;
+    
+        // 이미 열려 있으면 닫기
+        if (isLocationOpen) {
+            setIsLocationOpen(false);
+            return;
+        }
+    
+        try {
+            setIsLocationLoading(true);
+    
+            const locationData = await getTeamLiveLocations(team.teamId);
+            setLiveLocations(locationData);
+            setIsLocationOpen(true);
+        } catch (error) {
+            console.error("팀 실시간 위치 조회 실패:", error);
+            Alert.alert("오류", "팀원들의 위치 정보를 불러오지 못했습니다.");
+        } finally {
+            setIsLocationLoading(false);
+        }
+    };
+
+    if (!team) {
+        return (
+        <View style={styles.centerContainer}>
+            <Text style={styles.emptyTitle}>팀 정보가 없습니다.</Text>
+
+            <TouchableOpacity style={styles.retryButton} onPress={fetchTeamInfo}>
+                <Text style={styles.retryButtonText}>다시 불러오기</Text>
+            </TouchableOpacity>
+        </View>
+        );
+    }
+
+    return (
+    <ScrollView 
+        style={styles.container}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+    >
+        <Text style={styles.headerTitle}>팀 페이지</Text>
+        
+        <View style={styles.teamCard}>
+            <View style={styles.teamImage}>
+                <Text style={styles.teamImageText}>✈️</Text>
+            </View>
+
+            <Text style={styles.teamName}>{team.teamName}</Text>
+
+            <View style={styles.codeRow}>
+                <Text style={styles.codeLabel}>팀 코드</Text>
+                <Text style={styles.codeValue}>{team.teamCode}</Text>
+            </View>
+
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>팀 ID</Text>
+                <Text style={styles.infoValue}>{team.teamId}</Text>
+            </View>
+
+            <View style={styles.infoRow}>
+                <Text style={styles.infoLabel}>생성일</Text>
+                <Text style={styles.infoValue}>
+                    {new Date(team.createdAt).toLocaleDateString("ko-KR")}
+                </Text>
+            </View>
+        </View>
+
+        {/*팀원 목록*/}
+        <TouchableOpacity style={styles.menuItem} onPress={handlePressMembers}>
+            <View style={styles.menuTitleRow}>
+        <       Text style={styles.menuTitle}>팀원 목록</Text>
+                <Text style={styles.menuArrow}>{isMemberOpen ? "▲" : "▼"}</Text>
+            </View>
+            <Text style={styles.menuDescription}>팀원들의 정보를 확인해요</Text>
+        </TouchableOpacity>
+
+        {isMemberOpen && (
+            <View style={styles.memberListBox}>
+                {isMemberLoading ? (
+                    <View style={styles.memberLoadingBox}>
+                        <ActivityIndicator size="small" />
+                        <Text style={styles.memberLoadingText}>팀원 목록을 불러오는 중...</Text>
+                    </View>
+                ) : members.length === 0 ? (
+                    <Text style={styles.emptyMemberText}>팀원이 없습니다.</Text>
+                ) : (
+                    members.map((member) => (
+                        <View key={member.userId} style={styles.memberItem}>
+                            {member.profileImg && member.profileImg.trim() !== "" ? (
+                                <Image
+                                source={{ uri: member.profileImg }}
+                                style={styles.memberProfileImage}
+                                />
+                            ) : (
+                            <View style={styles.memberProfile}>
+                                <Text style={styles.memberProfileText}>
+                                    {member.nickname.charAt(0)}
+                                </Text>
+                            </View>
+                            )}
+
+                            <View style={styles.memberInfo}>
+                                <Text style={styles.memberName}>{member.nickname}</Text>
+                                <Text style={styles.memberRole}>
+                                    {member.role === "LEADER" ? "팀장" : "팀원"}
+                                </Text>
+                            </View>
+
+                            <View
+                                style={[
+                                    styles.roleBadge,
+                                    member.role === "LEADER"
+                                        ? styles.leaderBadge
+                                        : styles.memberBadge,
+                                    ]}
+                            >
+                                <Text
+                                    style={[
+                                        styles.roleBadgeText,
+                                        member.role === "LEADER"
+                                            ? styles.leaderBadgeText
+                                            : styles.memberBadgeText,
+                                    ]}
+                                >
+                                    {member.role === "LEADER" ? "LEADER" : "MEMBER"}
+                                </Text>
+                            </View>
+                        </View>
+                    ))
+                )}
+            </View>
+        )}
+
+        {/*실시간 위치*/}
+        <TouchableOpacity style={styles.menuItem} onPress={handlePressLiveLocations}>
+            <View style={styles.menuTitleRow}>
+                <Text style={styles.menuTitle}>실시간 위치</Text>
+                <Text style={styles.menuArrow}>{isLocationOpen ? "▲" : "▼"}</Text>
+            </View>
+            <Text style={styles.menuDescription}>팀원들의 현재 위치를 확인해요</Text>
+        </TouchableOpacity>
+
+        {isLocationOpen && (
+            <View style={styles.locationListBox}>
+                {isLocationLoading ? (
+                    <View style={styles.memberLoadingBox}>
+                        <ActivityIndicator size="small" />
+                        <Text style={styles.memberLoadingText}>
+                            위치 정보를 불러오는 중...
+                        </Text>
+                    </View>
+                ) : liveLocations.length === 0 ? (
+                <Text style={styles.emptyMemberText}>
+                    현재 위치를 공유 중인 팀원이 없습니다.
+                </Text>
+                ) : (
+                    liveLocations.map((location) => (
+                    <View key={location.userId} style={styles.locationItem}>
+                        <View style={styles.locationIcon}>
+                            <Text style={styles.locationIconText}>📍</Text>
+                        </View>
+                        
+                        <View style={styles.locationInfo}>
+                            <Text style={styles.locationName}>
+                                {location.nickname}
+                            </Text>
+                            
+                            <Text style={styles.locationPlace}>
+                                {location.placeName || "장소명 없음"}
+                            </Text>
+
+                            <Text style={styles.locationDetail}>
+                                위도 {location.latitude}, 경도 {location.longitude}
+                            </Text>
+
+                            <Text style={styles.locationTime}>
+                                최근 공유: {new Date(location.timestamp).toLocaleString("ko-KR")}
+                            </Text>
+                        </View>
+                    </View>
+                    ))
+                )}
+            </View>
+        )}
+
+        {/*팀 탈퇴하기*/}
+        <TouchableOpacity style={styles.leaveButton} onPress={handleLeaveTeam}>
+            <Text style={styles.leaveButtonText}>팀 탈퇴하기</Text>
+        </TouchableOpacity>
+    </ScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        backgroundColor: "#FFFFFF",
+    },
+    scrollContent: {
+        paddingHorizontal: 20,
+        paddingTop: 60,
+        paddingBottom: 120,
+    },
+    centerContainer: {
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#FFFFFF",
+    },
+    loadingText: {
+        marginTop: 12,
+        fontSize: 14,
+        color: "#777777",
+    },
+    emptyTitle: {
+        fontSize: 16,
+        fontWeight: "600",
+        color: "#333333",
+    },
+    retryButton: {
+        marginTop: 16,
+        paddingHorizontal: 20,
+        paddingVertical: 10,
+        borderRadius: 12,
+        backgroundColor: "#1A3A6B",
+    },
+    retryButtonText: {
+        color: "#FFFFFF",
+        fontWeight: "600",
+    },
+    headerTitle: {
+        fontSize: 24,
+        fontWeight: "700",
+        color: "#111111",
+        marginBottom: 20,
+    },
+    teamCard: {
+        borderRadius: 24,
+        padding: 24,
+        backgroundColor: "#E5ECFC",
+        alignItems: "center",
+        marginBottom: 20,
+    },
+    teamImage: {
+        width: 82,
+        height: 82,
+        borderRadius: 41,
+        backgroundColor: "#B2CAFF",
+        alignItems: "center",
+        justifyContent: "center",
+        marginBottom: 14,
+    },
+    teamImageText: {
+        fontSize: 34,
+    },
+    teamName: {
+        fontSize: 22,
+        fontWeight: "700",
+        color: "#111111",
+        marginBottom: 16,
+    },
+    codeRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        backgroundColor: "#FFFFFF",
+        borderRadius: 16,
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+        marginBottom: 12,
+        width: "100%",
+        justifyContent: "space-between",
+    },
+    codeLabel: {
+        fontSize: 14,
+        color: "#777777",
+    },
+    codeValue: {
+        fontSize: 15,
+        fontWeight: "700",
+        color: "#2DC59F",
+    },
+    infoRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        width: "100%",
+        paddingVertical: 8,
+    },
+    infoLabel: {
+        fontSize: 14,
+        color: "#777777",
+    },
+    infoValue: {
+        fontSize: 14,
+        color: "#222222",
+        fontWeight: "500",
+    },
+    menuItem: {
+        padding: 18,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#EEEEEE",
+        marginBottom: 12,
+        backgroundColor: "#FFFFFF",
+    },
+    menuTitle: {
+        fontSize: 16,
+        fontWeight: "700",
+        color: "#222222",
+    },
+    menuDescription: {
+        marginTop: 4,
+        fontSize: 13,
+        color: "#888888",
+    },
+    leaveButton: {
+        height: 52,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderColor: "#FF4D4F",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    leaveButtonText: {
+        color: "#FF4D4F",
+        fontSize: 15,
+        fontWeight: "700",
+    },
+    menuTitleRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+    },
+    menuArrow: {
+        fontSize: 14,
+        color: "#888888",
+    },
+    memberListBox: {
+        padding: 16,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#EEEEEE",
+        backgroundColor: "#FFFFFF",
+        marginTop: -4,
+        marginBottom: 12,
+    },
+    memberLoadingBox: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        paddingVertical: 12,
+    },
+    memberLoadingText: {
+        marginLeft: 8,
+        fontSize: 13,
+        color: "#777777",
+    },
+    emptyMemberText: {
+        fontSize: 14,
+        color: "#888888",
+        textAlign: "center",
+        paddingVertical: 12,
+    },
+    memberItem: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingVertical: 10,
+        borderBottomWidth: 1,
+        borderBottomColor: "#F0F0F0",
+    },
+    memberProfile: {
+        width: 42,
+        height: 42,
+        borderRadius: 21,
+        backgroundColor: "#E5ECFC",
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 12,
+    },
+    memberProfileText: {
+        fontSize: 16,
+        fontWeight: "700",
+        color: "#1A3A6B",
+    },
+    memberInfo: {
+        flex: 1,
+    },
+    memberName: {
+        fontSize: 15,
+        fontWeight: "700",
+        color: "#222222",
+    },
+    memberRole: {
+        marginTop: 3,
+        fontSize: 12,
+        color: "#888888",
+    },
+    roleBadge: {
+        paddingHorizontal: 10,
+        paddingVertical: 5,
+        borderRadius: 999,
+    },
+    leaderBadge: {
+        backgroundColor: "#E5ECFC",
+    },
+    memberBadge: {
+        backgroundColor: "#F2F2F2",
+    },
+    roleBadgeText: {
+        fontSize: 11,
+        fontWeight: "700",
+    },
+    leaderBadgeText: {
+        color: "#1A3A6B",
+    },
+    memberBadgeText: {
+        color: "#777777",
+    },
+    memberProfileImage: {
+        width: 42,
+        height: 42,
+        borderRadius: 21,
+        marginRight: 12,
+        backgroundColor: "#E5ECFC",
+    },
+    locationListBox: {
+        padding: 16,
+        borderRadius: 18,
+        borderWidth: 1,
+        borderColor: "#EEEEEE",
+        backgroundColor: "#FFFFFF",
+        marginTop: -4,
+        marginBottom: 12,
+    },
+    locationItem: {
+        flexDirection: "row",
+        paddingVertical: 12,
+        borderBottomWidth: 1,
+        borderBottomColor: "#F0F0F0",
+    },
+    locationIcon: {
+        width: 42,
+        height: 42,
+        borderRadius: 21,
+        backgroundColor: "#E5ECFC",
+        alignItems: "center",
+        justifyContent: "center",
+        marginRight: 12,
+    },
+    locationIconText: {
+        fontSize: 18,
+    },
+    locationInfo: {
+        flex: 1,
+    },
+    locationName: {
+        fontSize: 15,
+        fontWeight: "700",
+        color: "#222222",
+    },
+    locationPlace: {
+        marginTop: 4,
+        fontSize: 14,
+        color: "#1A3A6B",
+        fontWeight: "600",
+    },
+    locationDetail: {
+        marginTop: 3,
+        fontSize: 12,
+        color: "#888888",
+    },
+    locationTime: {
+        marginTop: 3,
+        fontSize: 11,
+        color: "#AAAAAA",
+    },
+});

--- a/src/features/team/types/team.types.ts
+++ b/src/features/team/types/team.types.ts
@@ -1,0 +1,26 @@
+// 팀 기본 정보 관련 타입
+export type TeamInfo = {
+    teamId: number;
+    teamName: string;
+    teamCode: string;
+    createdAt: string;
+};
+
+// 팀원 목록 조회 관련 타입
+export type TeamMember = {
+    userId: number;
+    nickname: string;
+    profileImg: string | null;
+    role: "LEADER" | "MEMBER";
+};
+
+// 팀 실시간 위치 조회 관련 타입
+export type TeamLiveLocation = {
+    userId: number;
+    nickname: string;
+    latitude: number;
+    longitude: number;
+    placeName: string;
+    passportId: number;
+    timestamp: string;
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #101 

## 📝 작업 내용
#### 1. 팀 정보 조회
- `GET /api/v1/teams/{teamId}` API 연결
- API 응답이 성공하면 `setTeam(data)`를 통해 팀 정보를 상태에 저장한 후,  화면의 팀 카드에 팀 이름, 팀 코드, 팀 ID, 생성일을 표시

#### 2. 팀 멤버 목록 조회
- `GET /api/v1/teams/{teamId}/members` API 연결
- 응답이 성공하면 팀원 닉네임, 프로필 이미지, 역할 정보를 화면에 표시
- `role` 값이 `LEADER`이면 “팀장”, `MEMBER`이면 “팀원”으로 구분하여 보여주도록 처리
- `profileImg`가 존재하면 `Image` 컴포넌트로 사용자 프로필 이미지를 표시하고, 이미지가 없으면 닉네임 첫 글자를 기본 프로필처럼 표시하도록 구성

#### 3. 팀 실시간 위치 조회
- `GET /api/v1/teams/{teamId}/live-locations` API 연결
- API 응답이 성공하면 위치를 공유 중인 팀원의 닉네임, 장소명, 위도, 경도, 최근 공유 시간을 화면에 표시
- 추후 지도 화면과 연결할 수 있도록 API 응답의 `latitude`, `longitude` 값을 그대로 관리하도록 설계

#### 4. 팀 탈퇴
- `DELETE /api/v1/teams/{teamId}/members/me` API 연결
- 탈퇴 버튼 클릭 시 바로 API를 호출하지 않고, `Alert`를 통해 사용자의 탈퇴 의사를 한 번 더 확인하도록 구현
- API 응답이 성공하면 `SecureStore`에 저장된 `teamId`, `teamCode`, `teamName`을 삭제
- 탈퇴 성공 후에는 `setTeam(null)`을 통해 현재 화면에서 팀 정보가 사라지도록 처리
- 실패 시 서버에서 내려준 `message`를 이용해 탈퇴 실패 알림을 표시하도록 구현
- `LEADER`는 탈퇴할 수 없기 때문에, 팀장 계정에서 실패하는 경우는 백엔드 정책에 따른 정상 동작으로 처리

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

