### PR TITLE
feat: 위치 공유 API 연결

### DIFF
--- a/src/api/profileApi.ts
+++ b/src/api/profileApi.ts
@@ -11,7 +11,8 @@ import {
     ProfileEditForm,
     ProfileUser,
     TeamResponseData,
-    UpdateProfileRequest,
+    UpdateLiveLocationSharingRequest,
+    UpdateProfileRequest
 } from "../features/profile/types/profile.types";
 import { BASE_URL } from "./config";
 
@@ -355,4 +356,42 @@ export const joinTeam = async (
     await Securestore.setItemAsync("teamName", teamData.teamName);
 
     return teamData;
+};
+
+// 11. 위치 공유 온오프 API
+export const updateLiveLocationSharing = async (
+    teamId: number,
+    sharing: boolean
+): Promise<void> => {
+    const accessToken = await getAccessToken();
+
+    const response = await fetch(
+        `${BASE_URL}/api/v1/teams/${teamId}/live-locations/me`,
+        {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${accessToken}`,
+            },
+            body: JSON.stringify({
+                sharing,
+            } satisfies UpdateLiveLocationSharingRequest),
+        }
+    );
+
+    console.log("위치 공유 온오프 상태:", response.status);
+
+    if (!response.ok) {
+        let errorMessage = "위치 공유 설정 변경 실패";
+
+        try {
+            const result = await response.json();
+            console.log("위치 공유 온오프 에러 응답:", result);
+            errorMessage = result.message || errorMessage;
+        } catch {
+            console.log("위치 공유 온오프 응답 body 없음");
+        }
+
+        throw new Error(errorMessage);
+    }
 };

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,4 +1,4 @@
-import { getMyProfile, logout } from "@/src/api/profileApi";
+import { getMyProfile, logout, updateLiveLocationSharing } from "@/src/api/profileApi";
 import { useTeamMode } from "@/src/components/common/TeamModeContext";
 import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
 import { useFocusEffect, useRouter } from "expo-router";
@@ -12,7 +12,7 @@ import {
     StyleSheet,
     Text,
     TouchableOpacity,
-    View
+    View,
 } from "react-native";
 import FriendManageModal from "../components/FriendManageModal";
 import TeamManageModal from "../components/TeamManageModal";
@@ -34,6 +34,9 @@ export default function ProfileView() {
 
     const [isTeamModalOpen, setIsTeamModalOpen] = useState(false);
     const [isFriendModalOpen, setIsFriendModalOpen] = useState(false);
+    
+    const [isLocationSharing, setIsLocationSharing] = useState(false);
+    const [isLocationSharingLoading, setIsLocationSharingLoading] = useState(false);
     
     // 메뉴 클릭 함수
     const handleMenuPress = (item: ProfileMenuItem) => {
@@ -88,6 +91,48 @@ export default function ProfileView() {
             ]
         )
     }
+
+    // 위치 공유 토글 함수
+    const handleToggleLocationSharing = async () => {
+
+        if (isLocationSharingLoading) return;
+
+        const nextValue = !isLocationSharing;
+
+        try {
+            setIsLocationSharingLoading(true);
+    
+            const savedTeamId = await Securestore.getItemAsync("teamId");
+    
+            console.log("위치 공유 변경 teamId:", savedTeamId);
+            console.log("위치 공유 변경 값:", nextValue);
+    
+            if (!savedTeamId) {
+                Alert.alert("알림", "소속된 팀 정보가 없습니다.");
+                return;
+            }
+    
+            await updateLiveLocationSharing(Number(savedTeamId), nextValue);
+    
+            setIsLocationSharing(nextValue);
+    
+            Alert.alert(
+                "완료",
+                nextValue ? "위치 공유가 켜졌습니다." : "위치 공유가 꺼졌습니다."
+            );
+        } catch (error) {
+            console.error("위치 공유 설정 변경 실패:", error);
+    
+            Alert.alert(
+                "오류",
+                error instanceof Error
+                    ? error.message
+                    : "위치 공유 설정을 변경하지 못했습니다."
+            );
+        } finally {
+            setIsLocationSharingLoading(false);
+        }
+    };
 
     useFocusEffect(
         useCallback (() => {
@@ -210,6 +255,43 @@ export default function ProfileView() {
                                 />
                             </TouchableOpacity>
                         </View>
+
+                        {isTeamMode && (
+                            <View style={[styles.menuItem, styles.menuItemBorder]}>
+                                <View style={styles.menuLeft}>
+                                    <View style={styles.iconBox}>
+                                        <Ionicons name="location" size={22} color="#FFFFFF" />
+                                    </View>
+                                        
+                                    <View style={styles.locationShareTextBox}>
+                                        <Text style={styles.menuTitle}>위치 공유</Text>
+                                        <Text style={styles.menuDescription}>
+                                            팀원들에게 내 현재 위치를 공유합니다.
+                                        </Text>
+                                    </View>
+                                </View>
+                                    
+                                <TouchableOpacity
+                                    activeOpacity={0.8}
+                                    disabled={isLocationSharingLoading}
+                                    style={[
+                                        styles.teamToggle,
+                                        isLocationSharing ? styles.teamToggleOn : styles.teamToggleOff,
+                                        isLocationSharingLoading && styles.toggleDisabled,
+                                    ]}
+                                    onPress={handleToggleLocationSharing}
+                                >
+                                    <View
+                                        style={[
+                                            styles.teamToggleCircle,
+                                            isLocationSharing
+                                                ? styles.teamToggleCircleOn
+                                                : styles.teamToggleCircleOff,
+                                        ]}
+                                    />
+                                </TouchableOpacity>
+                            </View>
+                        )}
     
                         {settingMenuDummy.map((item, index) => (
                             <TouchableOpacity
@@ -428,7 +510,13 @@ const styles = StyleSheet.create({
         fontSize: 12,
         fontWeight: "500",
     },
-
+    locationShareTextBox: {
+        flex: 1,
+        marginRight: 12,
+    },
+    toggleDisabled: {
+        opacity: 0.5,
+    },
     /*설정, 계정*/
     sectionSet: {
         marginBottom: 20,

--- a/src/features/profile/types/profile.types.ts
+++ b/src/features/profile/types/profile.types.ts
@@ -122,3 +122,8 @@ export type TeamResponseData = {
     teamCode: string;
     createdAt: string;
 };
+
+// 위치 공유 온오프 요청
+export type UpdateLiveLocationSharingRequest = {
+    sharing: boolean;
+}


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> `Closes #이슈번호` 형식으로 관련 이슈를 연결해주세요.
Closes #101 

## 📝 작업 내용
마이페이지 내 위치 공유 토글 UI 구현 및 API 연결
`/api/v1/teams/{teamId}/live-locations` 

<방식>
- 마이페이지에서 팀 모드가 활성화되었을 때만 위치 공유 토글이 보이도록 구현
- 토글을 누르면 현재 공유 상태의 반대값을 계산하여 PATCH /api/v1/teams/{teamId}/live-locations/me API를 호출

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 변경 사항에 대한 테스트를 진행했습니다.

