### PR TITLE
feat: 마이페이지·둘러보기 UI 개선

### DIFF
--- a/src/features/profile/data/profileDummy.ts
+++ b/src/features/profile/data/profileDummy.ts
@@ -53,12 +53,6 @@ export const accountMenuDummy: ProfileMenuItem[] = [
         route: "/profile/terms",
     },
     {
-        id: "subscribe",
-        title: "구독하기",
-        icon: "storefront",
-        route: "/profile/subscribe",
-    },
-    {
         id: "logout",
         title: "로그아웃",
         icon: "log-out",

--- a/src/features/profile/screens/profilesScreen.tsx
+++ b/src/features/profile/screens/profilesScreen.tsx
@@ -1,6 +1,7 @@
 import { getMyProfile, logout } from "@/src/api/profileApi";
 import { useTeamMode } from "@/src/components/common/TeamModeContext";
-import { Ionicons, MaterialCommunityIcons } from "@expo/vector-icons";
+import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
 import { useFocusEffect, useRouter } from "expo-router";
 import * as Securestore from "expo-secure-store";
 import { useCallback, useState } from "react";
@@ -16,7 +17,6 @@ import {
     View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import LogoIcon from "../../../../assets/icons/logo-white.svg";
 import FriendManageModal from "../components/FriendManageModal";
 import TeamManageModal from "../components/TeamManageModal";
 import {
@@ -244,6 +244,12 @@ export default function ProfileView() {
                         </Text>
                     </View>
                 </View>
+
+                <LinearGradient
+                    colors={["#F8FAFD", "rgba(248, 250, 253, 0)"]}
+                    style={styles.headerFade}
+                    pointerEvents="none"
+                />
             </View>
 
             <ScrollView
@@ -255,38 +261,6 @@ export default function ProfileView() {
                 showsVerticalScrollIndicator={false}
                 contentInsetAdjustmentBehavior="never"
             >
-                <View style={styles.premiumSection}>
-                    <MaterialCommunityIcons
-                        name="crown-outline"
-                        size={16}
-                        color="#B38E06"
-                    />
-                    <Text style={styles.premium}>프리미엄</Text>
-                </View>
-
-                <TouchableOpacity style={styles.bannerCard} activeOpacity={0.8}>
-                    <View style={styles.bannerTextBox}>
-                        <Text
-                            style={styles.bannerTitle}
-                            numberOfLines={1}
-                            ellipsizeMode="tail"
-                        >
-                            실물 여권 제작 신청
-                        </Text>
-                        <Text
-                            style={styles.bannerSubtitle}
-                            numberOfLines={2}
-                            ellipsizeMode="tail"
-                        >
-                            나만의 탐험 기록을 실물 책으로
-                        </Text>
-                    </View>
-
-                    <View style={styles.bannerIcon}>
-                        <LogoIcon width={30} height={30} />
-                    </View>
-                </TouchableOpacity>
-
                 <View style={styles.sectionSet}>
                     <View style={styles.menuBox}>
                         <View style={[styles.menuItem, styles.menuItemBorder]}>
@@ -508,6 +482,14 @@ const styles = StyleSheet.create({
         paddingHorizontal: 20,
         paddingTop: 11,
         backgroundColor: "#F8FAFD",
+        zIndex: 1,
+    },
+    headerFade: {
+        position: "absolute",
+        bottom: -24,
+        left: 0,
+        right: 0,
+        height: 24,
     },
     scrollArea: {
         flex: 1,
@@ -515,6 +497,7 @@ const styles = StyleSheet.create({
     },
     scrollContent: {
         paddingHorizontal: 20,
+        paddingTop: 10,
         paddingBottom: 20,
     },
     sectionAccount: {
@@ -625,46 +608,6 @@ const styles = StyleSheet.create({
         justifyContent: "center",
         alignItems: "center",
         backgroundColor: "#F8FAFD",
-    },
-    premiumSection: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: 5,
-        marginBottom: 5,
-    },
-    premium: {
-        color: "#B38E06",
-        fontSize: 14,
-        fontWeight: "800",
-    },
-    bannerCard: {
-        backgroundColor: "#FFE06E",
-        borderRadius: 15,
-        paddingHorizontal: 16,
-        paddingVertical: 16,
-        marginBottom: 21,
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-    },
-    bannerTextBox: {
-        flex: 1,
-        minWidth: 0,
-        marginRight: 8,
-    },
-    bannerIcon: {
-        flexShrink: 0,
-    },
-    bannerTitle: {
-        color: "#000000",
-        fontSize: 16,
-        fontWeight: "800",
-        marginBottom: 4,
-    },
-    bannerSubtitle: {
-        color: "#000000",
-        fontSize: 12,
-        fontWeight: "500",
     },
     locationShareTextBox: {
         flex: 1,

--- a/src/features/search/components/SearchToggle.tsx
+++ b/src/features/search/components/SearchToggle.tsx
@@ -1,4 +1,11 @@
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import {
+    Animated,
+    LayoutChangeEvent,
+    StyleSheet,
+    TouchableOpacity,
+    View,
+} from "react-native";
 import { SearchTab } from "../types/search.types";
 
 type SearchToggleProps = {
@@ -6,41 +13,109 @@ type SearchToggleProps = {
     onChangeTab: (tab: SearchTab) => void;
 }
 
+type TabLayout = {
+    x: number;
+    width: number;
+}
+
 export default function SearchToggle({selectedTab, onChangeTab}: SearchToggleProps) {
+    const progress = useRef(
+        new Animated.Value(selectedTab === "ranking" ? 1 : 0),
+    ).current;
+    const [tabLayouts, setTabLayouts] = useState<
+        Partial<Record<SearchTab, TabLayout>>
+    >({});
+
+    const isReady = !!tabLayouts.all && !!tabLayouts.ranking;
+
+    useEffect(() => {
+        Animated.timing(progress, {
+            toValue: selectedTab === "ranking" ? 1 : 0,
+            duration: 200,
+            useNativeDriver: false,
+        }).start();
+    }, [selectedTab, progress]);
+
+    const handleTabLayout =
+        (tab: SearchTab) => (event: LayoutChangeEvent) => {
+            const { x, width } = event.nativeEvent.layout;
+
+            setTabLayouts((prev) => {
+                const prevLayout = prev[tab];
+
+                if (
+                    prevLayout &&
+                    prevLayout.x === x &&
+                    prevLayout.width === width
+                ) {
+                    return prev;
+                }
+
+                return { ...prev, [tab]: { x, width } };
+            });
+        };
+
+    const pillStyle = isReady
+        ? {
+              left: progress.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [tabLayouts.all!.x, tabLayouts.ranking!.x],
+              }),
+              width: progress.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [
+                      tabLayouts.all!.width,
+                      tabLayouts.ranking!.width,
+                  ],
+              }),
+          }
+        : null;
+
+    const allTextColor = progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: ["#FFFFFF", "#000000"],
+    });
+    const rankingTextColor = progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: ["#000000", "#FFFFFF"],
+    });
+
     return (
         <View style={styles.toggleBox}>
+            {isReady && <Animated.View style={[styles.pill, pillStyle]} />}
+
             <TouchableOpacity
                 style={[
                     styles.toggleButton,
-                    selectedTab === "all" && styles.activeToggle,
+                    !isReady && selectedTab === "all" && styles.activeToggle,
                 ]}
+                activeOpacity={0.8}
+                onLayout={handleTabLayout("all")}
                 onPress={() => onChangeTab("all")}
             >
-                <Text
-                    style={[
-                        styles.toggleText,
-                        selectedTab === "all" && styles.activeToggleText,
-                    ]}
+                <Animated.Text
+                    style={[styles.toggleText, { color: allTextColor }]}
                 >
                     전체
-                </Text>
+                </Animated.Text>
             </TouchableOpacity>
 
             <TouchableOpacity
                 style={[
                     styles.toggleButton,
-                    selectedTab === "ranking" && styles.activeToggle,
+                    !isReady &&
+                        selectedTab === "ranking" &&
+                        styles.activeToggle,
                 ]}
+                activeOpacity={0.8}
+                onLayout={handleTabLayout("ranking")}
                 onPress={() => onChangeTab("ranking")}
             >
-                <Text
-                    style={[
-                        styles.toggleText,
-                        selectedTab === "ranking" && styles.activeToggleText,
-                    ]}
+                <Animated.Text
+                    style={[styles.toggleText, { color: rankingTextColor }]}
                 >
                     랭킹
-                </Text>
+                </Animated.Text>
             </TouchableOpacity>
         </View>
     )
@@ -54,6 +129,13 @@ const styles = StyleSheet.create({
         borderColor: "#c6c6c6",
         borderWidth: 2.5,
     },
+    pill: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        borderRadius: 18,
+        backgroundColor: "#1A3A6B",
+    },
     toggleButton: {
         paddingHorizontal: 12,
         paddingVertical: 5,
@@ -64,11 +146,6 @@ const styles = StyleSheet.create({
     },
     toggleText: {
         fontSize: 12,
-        color: "#000000",
         fontWeight: "500",
     },
-    activeToggleText: {
-        color: "#FFFFFF",
-        fontWeight: "500",
-    }
 })

--- a/src/features/search/screens/searchScreen.tsx
+++ b/src/features/search/screens/searchScreen.tsx
@@ -1,6 +1,12 @@
 import { Ionicons } from "@expo/vector-icons";
-import { useState } from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import {
+    Animated,
+    StyleSheet,
+    Text,
+    TouchableOpacity,
+    View,
+} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import AllSearchContent from "../components/AllSearchContent";
 import RankingContent from "../components/RankingContent";
@@ -17,6 +23,24 @@ export default function SearchView() {
     const [rankingMode, setRankingMode] = useState<RankingMode>("total");
     const [isRankingDropdownOpen, setIsRankingDropdownOpen] = useState(false);
 
+    const contentOpacity = useRef(new Animated.Value(1)).current;
+    const isFirstRender = useRef(true);
+
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false;
+            return;
+        }
+
+        contentOpacity.setValue(0);
+
+        Animated.timing(contentOpacity, {
+            toValue: 1,
+            duration: 220,
+            useNativeDriver: true,
+        }).start();
+    }, [selectedTab, contentOpacity]);
+
     const rankingTitle = 
         rankingMode === "total" ? "이번 주 랭킹" : "구별 랭킹";
 
@@ -28,6 +52,9 @@ export default function SearchView() {
     return (
         <SafeAreaView style={styles.container}>
             <View style={styles.header}>
+                <Animated.View
+                    style={[styles.titleArea, { opacity: contentOpacity }]}
+                >
                 {selectedTab === 'all' ? (
                     <Text style={styles.title}>둘러보기</Text>
                 ) : (
@@ -89,7 +116,8 @@ export default function SearchView() {
                         )}
                     </View>
                 )}
-                
+                </Animated.View>
+
                 <SearchToggle
                     selectedTab={selectedTab}
                     onChangeTab={(tab) => {
@@ -99,14 +127,18 @@ export default function SearchView() {
                 />
             </View>
 
-            {selectedTab === "all" ? (
-                <AllSearchContent 
-                    requestedFriendCodes ={requestedFriendCodes}
-                    setRequestedFriendCodes={setRequestedFriendCodes}
-                />
-            ) : (
-                <RankingContent rankingMode={rankingMode} />
-            )}
+            <Animated.View
+                style={[styles.contentArea, { opacity: contentOpacity }]}
+            >
+                {selectedTab === "all" ? (
+                    <AllSearchContent
+                        requestedFriendCodes ={requestedFriendCodes}
+                        setRequestedFriendCodes={setRequestedFriendCodes}
+                    />
+                ) : (
+                    <RankingContent rankingMode={rankingMode} />
+                )}
+            </Animated.View>
         </SafeAreaView>
     );
 }
@@ -126,6 +158,13 @@ const styles = StyleSheet.create({
         paddingTop: 12,
         zIndex: 100,
         elevation: 100,
+    },
+    contentArea: {
+        flex: 1,
+    },
+    titleArea: {
+        zIndex: 200,
+        elevation: 200,
     },
     rankingTitleWrapper: {
         position: "relative",


### PR DESCRIPTION
## 변경 사항

### 마이페이지
- 결제(구독하기) 메뉴와 실물 여권 제작 신청 배너 제거
- 상단 고정 프로필 카드와 스크롤 영역이 맞물리는 경계에 그라데이션 페이드 적용, 스크롤 시 메뉴가 부드럽게 사라지도록 개선

### 둘러보기
- 전체/랭킹 토글: 활성 배경(pill)이 슬라이드로 이동하고 글자색이 함께 전환되는 애니메이션 적용 (200ms)
- 탭 전환 시 콘텐츠와 상단 타이틀이 페이드로 전환되도록 개선 (220ms)

## 확인
- tsc 통과 (기존 cover_ai의 expo-asset 타입 에러 2건은 본 PR과 무관)
- expo export(android, 프로덕션 번들) 빌드 정상
- 에뮬레이터에서 마이페이지 페이드 및 토글 애니메이션 동작 확인