### PR TITLE
fix: 팀 상태 불일치·여권 편집 노출 등 QA 결함 수정

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -231,6 +231,10 @@ function TabsLayoutContent() {
     <Tabs
       tabBar={(props) => <CustomTabBar {...props} />}
       screenOptions={{ headerShown: false }}
+      // 기본값(firstRoute)이면 뒤로가기가 항상 첫 탭(여권)으로 간다.
+      // 하위 페이지(프로필 수정·스크랩 등)도 탭 라우트라 같은 문제를 겪는다.
+      // history 로 두면 직전에 보던 화면으로 돌아간다.
+      backBehavior="history"
     >
       <Tabs.Screen
         name="passport"

--- a/src/api/authToken.ts
+++ b/src/api/authToken.ts
@@ -50,11 +50,24 @@ export const saveTokens = async (accessToken: string, refreshToken?: string | nu
     }
 }
 
+// 계정에 종속된 로컬 데이터. 로그아웃·탈퇴·세션 만료 시 함께 지워야 한다.
+// 토큰만 지우면 다음 계정에서 이전 계정의 팀 정보가 그대로 보인다.
+const USER_SCOPED_KEYS = [
+    ACCESS_TOKEN_KEY,
+    REFRESH_TOKEN_KEY,
+    'teamId',
+    'teamCode',
+    'teamName',
+    'teamModeEnabled',
+    'liveLocationSharing',
+]
+
 export const clearTokens = async () => {
-    await Promise.all([
-        SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY).catch(() => undefined),
-        SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY).catch(() => undefined),
-    ])
+    await Promise.all(
+        USER_SCOPED_KEYS.map((key) =>
+            SecureStore.deleteItemAsync(key).catch(() => undefined),
+        ),
+    )
 }
 
 const BASE64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'

--- a/src/components/common/TeamModeContext.tsx
+++ b/src/components/common/TeamModeContext.tsx
@@ -100,8 +100,33 @@ export function TeamModeProvider({ children }: { children: ReactNode }) {
         SecureStore.getItemAsync("teamName")
             .then((name) => setTeamName(name))
             .catch(() => {});
+        // 저장된 플래그만 믿으면 안 된다. 팀에서 나갔거나 팀이 사라져도 플래그는 남아 있어서
+        // "팀에 가입된 것처럼" 보이는 상태가 생긴다. 켜져 있던 경우엔 서버에 실제로 확인한다.
         SecureStore.getItemAsync(TEAM_MODE_ENABLED_KEY)
-            .then((value) => setIsTeamMode(value === "true"))
+            .then(async (value) => {
+                if (value !== "true") {
+                    setIsTeamMode(false);
+                    return;
+                }
+
+                try {
+                    const teamInfo = await getMyTeam();
+
+                    setTeamId(String(teamInfo.teamId));
+                    setTeamName(teamInfo.teamName);
+                    setIsTeamMode(true);
+                } catch (error) {
+                    console.log("팀 모드 복원 중 팀 정보 조회 실패:", error);
+
+                    // 네트워크 문제로 확인이 안 된 것뿐일 수 있으므로 캐시는 지우지 않고,
+                    // 팀 모드만 꺼 둔다. 사용자가 다시 켜면 그때 서버로 확인한다.
+                    setIsTeamMode(false);
+                    SecureStore.setItemAsync(
+                        TEAM_MODE_ENABLED_KEY,
+                        "false",
+                    ).catch(() => {});
+                }
+            })
             .catch(() => {});
         SecureStore.getItemAsync(LIVE_LOCATION_SHARING_KEY)
             .then((value) => setIsLocationSharing(value === "true"))
@@ -429,8 +454,16 @@ export function TeamModeProvider({ children }: { children: ReactNode }) {
         const nextTeamMode = !isTeamMode;
 
         if (!nextTeamMode) {
+            // 끄는 동작은 어떤 이유로도 막히면 안 된다.
+            // 팀이 이미 없으면 setLocationSharing 이 getMyTeam 에서 예외를 던지는데,
+            // 그대로 두면 아래 setIsTeamMode(false) 까지 가지 못해 해제가 불가능해진다.
             if (isLocationSharingRef.current) {
-                await setLocationSharing(false);
+                await setLocationSharing(false).catch((error) => {
+                    console.log("팀 모드 해제 중 위치 공유 정리 실패:", error);
+
+                    isLocationSharingRef.current = false;
+                    setIsLocationSharing(false);
+                });
             } else {
                 const id =
                     teamId ??

--- a/src/features/map/screens/MapScreen.tsx
+++ b/src/features/map/screens/MapScreen.tsx
@@ -327,8 +327,9 @@ export default function MapScreen() {
     try {
       const res = await getPassportDetail(previewData.passportId);
       setDetailItem(res.data.data);
+      // previewData 를 비우면 상세에서 뒤로 왔을 때 내용 없는 빈 카드가 뜬다.
+      // 감추는 건 previewVisible 로만 처리한다.
       setPreviewVisible(false);
-      setPreviewData(null);
     } catch (e) {
       console.error("상세 조회 실패:", e);
     } finally {

--- a/src/features/passport/screens/PassportDetail.tsx
+++ b/src/features/passport/screens/PassportDetail.tsx
@@ -270,17 +270,70 @@ const PassportDetail = ({ item, onBack, onNext, onPrev, districts, editable = tr
             }
 
             if (isNewDistrict) {
+                // 서버에 '여권 이동' API 가 없어서 새로 만들고 원본을 지운다.
+                // 그 과정에서 좋아요·스크랩이 사라지므로 반드시 확인을 받는다.
+                const confirmed = await new Promise<boolean>((resolve) => {
+                    Alert.alert(
+                        '다른 지역으로 옮길까요?',
+                        `이 기록을 ${editDistrict} 로 옮기면 새 여권으로 다시 만들어집니다.` +
+                        `\n지금까지 받은 좋아요와 스크랩은 사라지며 되돌릴 수 없습니다.`,
+                        [
+                            { text: '취소', style: 'cancel', onPress: () => resolve(false) },
+                            { text: '옮기기', style: 'destructive', onPress: () => resolve(true) },
+                        ],
+                        { cancelable: true, onDismiss: () => resolve(false) },
+                    )
+                })
+
+                if (!confirmed) return
+
                 let imageUrls = item.imageUrls
                 if (!imageUrls || imageUrls.length === 0) {
                     const detailRes = await getPassportDetail(item.passportId)
                     imageUrls = detailRes.data?.data?.imageUrls ?? []
                 }
-                await createPassport({ ...passportData, imageUrls })
-                await deletePassport(item.passportId)
+
+                const createRes = await createPassport({ ...passportData, imageUrls })
+                const createdId = createRes?.data?.data?.passportId
+
+                try {
+                    await deletePassport(item.passportId)
+                } catch (deleteError) {
+                    // 원본 삭제가 실패하면 같은 기록이 두 개 남는다. 방금 만든 쪽을 되돌린다.
+                    console.error('원본 삭제 실패, 생성분 롤백:', deleteError)
+
+                    if (createdId) {
+                        await deletePassport(createdId).catch(() => {})
+                    }
+
+                    Alert.alert(
+                        '옮기지 못했어요',
+                        '기존 기록을 정리하지 못해 되돌렸습니다. 잠시 후 다시 시도해 주세요.',
+                    )
+                    return
+                }
+
                 onBack()
             } else {
                 await updatePassport(item.passportId, passportData)
                 await changePassportVisibility(item.passportId, visibility)
+
+                // 서버 수정 API 는 날짜·주소·좌표를 받지 않는다(설계상 수정 불가).
+                // 화면만 바뀐 채로 두면 다시 들어왔을 때 옛 값으로 돌아가 혼란스럽다.
+                const originalDate = (item.visitedAt ?? '').split('T')[0]
+                const isDateChanged =
+                    !!originalDate &&
+                    editDate.toISOString().split('T')[0] !== originalDate
+                const isPlaceChanged =
+                    !!item.address && editAddress !== item.address
+
+                if (isDateChanged || isPlaceChanged) {
+                    Alert.alert(
+                        '일부 항목은 저장되지 않았어요',
+                        '방문 날짜와 장소는 수정할 수 없어 원래 값으로 유지됩니다.',
+                    )
+                }
+
                 if (editDistrict !== originalDistrict) {
                     onBack()
                 } else {

--- a/src/features/passport/screens/PassportScreen.tsx
+++ b/src/features/passport/screens/PassportScreen.tsx
@@ -132,6 +132,8 @@ export default function PassportView() {
                         item={selectedPlaces[selectedIndex]}
                         districts={districts}
                         sourceLabel={activeTab === 'like' ? '좋아요' : activeTab === 'scrap' ? '스크랩' : undefined}
+                        // 좋아요/스크랩 탭은 남의 여권이다. 편집 UI 가 뜨면 안 된다.
+                        editable={activeTab === 'passport'}
                         onBack={() => {
                             updateSelectedPlaces([])
                             setSelectedIndex(0)

--- a/src/features/profile/components/TeamManageModal.tsx
+++ b/src/features/profile/components/TeamManageModal.tsx
@@ -1,4 +1,6 @@
 import { createTeam, joinTeam, searchTeamByCode } from "@/src/api/profileApi";
+import { getMyTeam, getTeamMembers, leaveTeam } from "@/src/api/teamApi";
+import { useTeamMode } from "@/src/components/common/TeamModeContext";
 import { Ionicons } from "@expo/vector-icons";
 import * as Securestore from "expo-secure-store";
 import { useEffect, useState } from "react";
@@ -32,32 +34,37 @@ export default function TeamManageModal({
     const [inviteCode, setInviteCode] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isSearching, setIsSearching] = useState(false);
+    // 입력 중인 칸을 강조하기 위한 상태
+    const [isInputFocused, setIsInputFocused] = useState(false);
     const [searchedTeam, setSearchedTeam] = useState<TeamResponseData | null>(null);
     const [currentTeam, setCurrentTeam] = useState<TeamResponseData | null>(null);
+    const [isLeaving, setIsLeaving] = useState(false);
+
+    // 탈퇴하면 팀 모드도 함께 꺼야 한다. 안 그러면 없는 팀으로 팀 모드가 남는다.
+    const { clearTeamMode, currentUserId } = useTeamMode();
 
     const isCreateMode = mode === "create";
 
     useEffect(() => {
         if (!visible) return;
 
+        // 로컬 캐시를 정본으로 쓰면 안 된다. 팀에서 나갔거나 계정이 바뀌어도 캐시가 남아
+        // "이미 팀에 속한" 것처럼 보이고, 그러면 팀 생성/가입 폼이 통째로 감춰진다.
         const loadCurrentTeam = async () => {
-            const [savedTeamId, savedTeamCode, savedTeamName] = await Promise.all([
-                Securestore.getItemAsync("teamId"),
-                Securestore.getItemAsync("teamCode"),
-                Securestore.getItemAsync("teamName"),
-            ]);
+            try {
+                const teamInfo = await getMyTeam();
 
-            if (!savedTeamId || !savedTeamCode || !savedTeamName) {
+                setCurrentTeam({
+                    teamId: teamInfo.teamId,
+                    teamCode: teamInfo.teamCode,
+                    teamName: teamInfo.teamName,
+                    createdAt: teamInfo.createdAt ?? "",
+                });
+            } catch (error) {
+                console.log("내 팀 정보 조회 실패:", error);
+
                 setCurrentTeam(null);
-                return;
             }
-
-            setCurrentTeam({
-                teamId: Number(savedTeamId),
-                teamCode: savedTeamCode,
-                teamName: savedTeamName,
-                createdAt: "",
-            });
         };
 
         loadCurrentTeam();
@@ -162,6 +169,69 @@ export default function TeamManageModal({
         }
     };
 
+    const handleLeaveTeam = async () => {
+        if (!currentTeam) return;
+
+        // 팀장이 나가면 서버가 팀을 해산하고 팀 여권까지 전부 삭제한다.
+        let isLeader = false;
+
+        try {
+            const memberList = await getTeamMembers(currentTeam.teamId);
+
+            isLeader = memberList.some(
+                (member) =>
+                    member.userId === currentUserId && member.role === "LEADER",
+            );
+        } catch (error) {
+            console.log("팀 역할 확인 실패:", error);
+        }
+
+        Alert.alert(
+            isLeader ? "팀 해산" : "팀 탈퇴",
+            isLeader
+                ? "팀장이 나가면 팀이 해산됩니다.\n팀원 전원의 팀 여권이 모두 삭제되며 되돌릴 수 없습니다.\n계속할까요?"
+                : "정말로 팀에서 탈퇴하시겠어요?",
+            [
+            { text: "취소", style: "cancel" },
+            {
+                text: isLeader ? "해산하기" : "탈퇴하기",
+                style: "destructive",
+                onPress: async () => {
+                    try {
+                        setIsLeaving(true);
+
+                        await leaveTeam(currentTeam.teamId);
+                        clearTeamMode();
+
+                        setCurrentTeam(null);
+                        setSearchedTeam(null);
+
+                        Alert.alert(
+                            "완료",
+                            isLeader
+                                ? "팀이 해산되었습니다."
+                                : "팀에서 탈퇴했습니다.",
+                        );
+                    } catch (error) {
+                        console.log("팀 탈퇴 실패:", error);
+
+                        Alert.alert(
+                            "탈퇴 실패",
+                            error instanceof Error
+                                ? error.message
+                                : "팀 탈퇴에 실패했습니다.",
+                        );
+                    } finally {
+                        setIsLeaving(false);
+                    }
+                },
+            },
+        ]);
+    };
+
+    const isSearchDisabled =
+        inviteCode.trim().length === 0 || isSearching || isSubmitting;
+
     const isDisabled = isCreateMode
         ? teamName.trim().length === 0 || isSubmitting
         : inviteCode.trim().length === 0 || isSubmitting || isSearching;
@@ -188,7 +258,10 @@ export default function TeamManageModal({
                         </TouchableOpacity>
                     </View>
 
-                    <View style={styles.tabContainer}>
+                    {/* 서버가 생성·가입을 모두 막으므로(TEAM_ALREADY_JOINED),
+                        이미 팀이 있으면 시도조차 못 하게 폼을 감춘다. */}
+                    {!currentTeam && (
+                    <View style={styles.tabTrack}>
                         <TouchableOpacity
                             activeOpacity={0.8}
                             style={[
@@ -227,6 +300,7 @@ export default function TeamManageModal({
                             </Text>
                         </TouchableOpacity>
                     </View>
+                    )}
 
                     {currentTeam && (
                         <View style={styles.currentTeamBox}>
@@ -280,17 +354,52 @@ export default function TeamManageModal({
                                     </Text>
                                 </TouchableOpacity>
                             </View>
+
+                            {/* 팀 화면(팀 모드 전용)에만 있던 탈퇴를 여기서도 할 수 있게 한다.
+                                팀이 있는 사용자는 이 모달을 먼저 열게 되는데, 기존에는
+                                여기서 팀을 벗어날 방법이 없었다. */}
+                            <TouchableOpacity
+                                activeOpacity={0.7}
+                                style={styles.leaveTeamButton}
+                                onPress={handleLeaveTeam}
+                                disabled={isSubmitting || isSearching || isLeaving}
+                            >
+                                {isLeaving ? (
+                                    <ActivityIndicator size="small" color="#C05A5A" />
+                                ) : (
+                                    <>
+                                        <Ionicons
+                                            name="exit-outline"
+                                            size={15}
+                                            color="#C05A5A"
+                                        />
+                                        <Text style={styles.leaveTeamText}>
+                                            팀 탈퇴하기
+                                        </Text>
+                                    </>
+                                )}
+                            </TouchableOpacity>
                         </View>
                     )}
 
-                    {isCreateMode ? (
+                    {currentTeam ? (
+                        <Text style={styles.alreadyJoinedNotice}>
+                            이미 팀에 속해 있어요. 다른 팀을 만들거나 가입하려면
+                            먼저 지금 팀에서 탈퇴해 주세요.
+                        </Text>
+                    ) : isCreateMode ? (
                         <View>
                             <View style={styles.formGroup}>
                                 <Text style={styles.label}>팀 이름</Text>
                                 <TextInput
-                                    style={styles.input}
+                                    style={[
+                                        styles.input,
+                                        isInputFocused && styles.inputFocused,
+                                    ]}
+                                    onFocus={() => setIsInputFocused(true)}
+                                    onBlur={() => setIsInputFocused(false)}
                                     placeholder="팀 이름을 입력해주세요"
-                                    placeholderTextColor="#A0A0A0"
+                                    placeholderTextColor="#9CA3AF"
                                     value={teamName}
                                     onChangeText={setTeamName}
                                     editable={!isSubmitting && !isSearching}
@@ -320,9 +429,15 @@ export default function TeamManageModal({
                             <View style={styles.formGroup}>
                                 <Text style={styles.label}>초대 코드</Text>
                                 <TextInput
-                                    style={styles.input}
-                                    placeholder="초대 코드를 입력해주세요"
-                                    placeholderTextColor="#A0A0A0"
+                                    style={[
+                                        styles.input,
+                                        styles.codeInput,
+                                        isInputFocused && styles.inputFocused,
+                                    ]}
+                                    onFocus={() => setIsInputFocused(true)}
+                                    onBlur={() => setIsInputFocused(false)}
+                                    placeholder="8자리 코드"
+                                    placeholderTextColor="#9CA3AF"
                                     value={inviteCode}
                                     onChangeText={handleChangeInviteCode}
                                     autoCapitalize="characters"
@@ -342,22 +457,21 @@ export default function TeamManageModal({
                                 activeOpacity={0.8}
                                 style={[
                                     styles.searchButton,
-                                    (inviteCode.trim().length === 0 ||
-                                        isSearching ||
-                                        isSubmitting) &&
-                                        styles.disableButton,
+                                    isSearchDisabled && styles.searchButtonDisabled,
                                 ]}
                                 onPress={handleSearchTeam}
-                                disabled={
-                                    inviteCode.trim().length === 0 ||
-                                    isSearching ||
-                                    isSubmitting
-                                }
+                                disabled={isSearchDisabled}
                             >
                                 {isSearching ? (
                                     <ActivityIndicator color="#1A3A6B" />
                                 ) : (
-                                    <Text style={styles.searchButtonText}>
+                                    <Text
+                                        style={[
+                                            styles.searchButtonText,
+                                            isSearchDisabled &&
+                                                styles.searchButtonTextDisabled,
+                                        ]}
+                                    >
                                         팀 코드로 검색
                                     </Text>
                                 )}
@@ -484,50 +598,56 @@ const styles = StyleSheet.create({
         backgroundColor: "rgba(0, 0, 0, 0.45)",
         justifyContent: "center",
         alignItems: "center",
-        paddingHorizontal: 24,
+        paddingHorizontal: 20,
     },
     modalBox: {
         width: "100%",
         backgroundColor: "#FFFFFF",
-        borderRadius: 15,
+        borderRadius: 20,
         paddingHorizontal: 20,
         paddingTop: 18,
-        paddingBottom: 22,
+        paddingBottom: 20,
         shadowColor: "#000000",
         shadowOffset: {
             width: 0,
-            height: 6,
+            height: 8,
         },
-        shadowOpacity: 0.18,
-        shadowRadius: 12,
+        shadowOpacity: 0.16,
+        shadowRadius: 20,
         elevation: 8,
     },
     header: {
         flexDirection: "row",
         justifyContent: "space-between",
         alignItems: "center",
-        marginBottom: 18,
+        marginBottom: 16,
     },
     title: {
-        color: "#000000",
-        fontSize: 24,
+        color: "#111827",
+        fontSize: 20,
         fontWeight: "700",
     },
+    // 아이콘만 두면 터치 영역이 좁다. 원형 버튼으로 넓힌다.
     closeButton: {
-        backgroundColor: "#FFFFFF",
+        width: 32,
+        height: 32,
+        borderRadius: 16,
+        backgroundColor: "#F2F5F9",
+        alignItems: "center",
+        justifyContent: "center",
     },
-    tabContainer: {
+    // 둘러보기의 전체/랭킹 토글과 같은 알약형 세그먼트로 맞춘다.
+    tabTrack: {
         flexDirection: "row",
-        gap: 10,
-        marginBottom: 22,
+        padding: 4,
+        borderRadius: 999,
+        backgroundColor: "#F2F5F9",
+        marginBottom: 20,
     },
     tabButton: {
         flex: 1,
-        height: 46,
-        borderRadius: 14,
-        borderWidth: 1,
-        borderColor: "#1A3A6B",
-        backgroundColor: "#FFFFFF",
+        height: 40,
+        borderRadius: 999,
         justifyContent: "center",
         alignItems: "center",
     },
@@ -535,19 +655,19 @@ const styles = StyleSheet.create({
         backgroundColor: "#1A3A6B",
     },
     tabText: {
-        color: "#A0A0A0",
-        fontSize: 15,
+        color: "#8A93A2",
+        fontSize: 14,
+        fontWeight: "600",
     },
     activeTabText: {
         color: "#FFFFFF",
+        fontWeight: "700",
     },
     currentTeamBox: {
-        padding: 14,
+        padding: 16,
         borderRadius: 16,
-        borderWidth: 1,
-        borderColor: "#D7E0ED",
-        backgroundColor: "#F7FAFF",
-        marginBottom: 18,
+        backgroundColor: "#EEF3FA",
+        marginBottom: 20,
     },
     currentTeamHeader: {
         flexDirection: "row",
@@ -559,38 +679,37 @@ const styles = StyleSheet.create({
         flex: 1,
     },
     currentTeamEyebrow: {
-        color: "#6F7785",
+        color: "#6B7280",
         fontSize: 12,
         fontWeight: "600",
         marginBottom: 4,
     },
     currentTeamName: {
-        color: "#111111",
+        color: "#111827",
         fontSize: 16,
-        fontWeight: "800",
+        fontWeight: "700",
     },
     currentTeamCodeBadge: {
-        paddingHorizontal: 10,
-        paddingVertical: 7,
-        borderRadius: 12,
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+        borderRadius: 10,
         backgroundColor: "#FFFFFF",
     },
     currentTeamCode: {
         color: "#1A3A6B",
-        fontSize: 14,
+        fontSize: 15,
         fontWeight: "800",
+        letterSpacing: 1,
     },
     currentTeamActionRow: {
         flexDirection: "row",
-        gap: 10,
-        marginTop: 12,
+        gap: 8,
+        marginTop: 14,
     },
     currentTeamActionButton: {
         flex: 1,
         height: 40,
-        borderRadius: 14,
-        borderWidth: 1,
-        borderColor: "#D7E0ED",
+        borderRadius: 12,
         backgroundColor: "#FFFFFF",
         flexDirection: "row",
         alignItems: "center",
@@ -602,38 +721,78 @@ const styles = StyleSheet.create({
         fontSize: 13,
         fontWeight: "700",
     },
+    // 되돌릴 수 없는 동작이라 눈에 덜 띄는 텍스트 버튼으로 둔다.
+    leaveTeamButton: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 5,
+        height: 36,
+        marginTop: 8,
+    },
+    leaveTeamText: {
+        color: "#C05A5A",
+        fontSize: 13,
+        fontWeight: "600",
+    },
+    alreadyJoinedNotice: {
+        color: "#6B7280",
+        fontSize: 13,
+        lineHeight: 20,
+        textAlign: "center",
+        paddingHorizontal: 8,
+        paddingBottom: 4,
+    },
     formGroup: {
-        marginBottom: 16,
+        marginBottom: 12,
     },
     label: {
-        color: "#333333",
-        fontSize: 14,
+        color: "#6B7280",
+        fontSize: 13,
         fontWeight: "600",
         marginBottom: 8,
     },
+    // 프로필 수정 화면의 입력칸과 같은 모양으로 통일한다.
     input: {
-        height: 50,
+        height: 48,
         borderWidth: 1,
-        borderColor: "#D9D9D9",
-        borderRadius: 14,
+        borderColor: "#E5EAF2",
+        borderRadius: 12,
         paddingHorizontal: 14,
-        backgroundColor: "#FFFFFF",
-        color: "#333333",
+        backgroundColor: "#F7F9FC",
+        color: "#111827",
         fontSize: 15,
-        marginBottom: -10,
+        fontWeight: "600",
+    },
+    inputFocused: {
+        borderColor: "#1A3A6B",
+        backgroundColor: "#FFFFFF",
+    },
+    // 초대 코드는 8자리 코드라 가운데 정렬 + 자간을 주면 읽기 쉽다.
+    codeInput: {
+        textAlign: "center",
+        letterSpacing: 4,
+        fontSize: 18,
+        fontWeight: "700",
     },
     noticeText: {
-        color: "#A0A0A0",
+        color: "#9CA3AF",
         fontSize: 12,
+        lineHeight: 16,
     },
     searchButton: {
-        height: 44,
+        height: 46,
         borderWidth: 1,
         borderColor: "#1A3A6B",
-        borderRadius: 18,
+        borderRadius: 14,
         justifyContent: "center",
         alignItems: "center",
         marginTop: 14,
+        backgroundColor: "#FFFFFF",
+    },
+    // 아웃라인 버튼은 배경을 회색으로 덮으면 안 된다. 선과 글자만 흐리게 한다.
+    searchButtonDisabled: {
+        borderColor: "#D7DDE7",
         backgroundColor: "#FFFFFF",
     },
     searchButtonText: {
@@ -641,14 +800,15 @@ const styles = StyleSheet.create({
         fontSize: 14,
         fontWeight: "700",
     },
+    searchButtonTextDisabled: {
+        color: "#AEB6C2",
+    },
     searchResultBox: {
         marginTop: 14,
-        padding: 14,
-        borderRadius: 14,
-        borderWidth: 1,
-        borderColor: "#D7E0ED",
-        backgroundColor: "#F7FAFF",
-        gap: 8,
+        padding: 16,
+        borderRadius: 16,
+        backgroundColor: "#EEF3FA",
+        gap: 10,
     },
     searchResultHeader: {
         flexDirection: "row",
@@ -668,13 +828,13 @@ const styles = StyleSheet.create({
         gap: 12,
     },
     searchResultLabel: {
-        color: "#6F7785",
+        color: "#6B7280",
         fontSize: 12,
         fontWeight: "600",
     },
     searchResultValue: {
         flex: 1,
-        color: "#222222",
+        color: "#374151",
         fontSize: 13,
         fontWeight: "600",
         textAlign: "right",
@@ -683,6 +843,7 @@ const styles = StyleSheet.create({
         color: "#1A3A6B",
         fontSize: 13,
         fontWeight: "800",
+        letterSpacing: 1,
     },
     searchResultActionRow: {
         flexDirection: "row",
@@ -693,8 +854,6 @@ const styles = StyleSheet.create({
         flex: 1,
         height: 36,
         borderRadius: 12,
-        borderWidth: 1,
-        borderColor: "#D7E0ED",
         backgroundColor: "#FFFFFF",
         flexDirection: "row",
         alignItems: "center",
@@ -707,19 +866,30 @@ const styles = StyleSheet.create({
         fontWeight: "700",
     },
     submitButton: {
-        height: 55,
-        backgroundColor: "#8C9CB5",
-        borderRadius: 24,
+        height: 54,
+        backgroundColor: "#1A3A6B",
+        borderRadius: 16,
         justifyContent: "center",
         alignItems: "center",
-        marginTop: 15,
+        marginTop: 16,
+
+        shadowColor: "#1A3A6B",
+        shadowOffset: {
+            width: 0,
+            height: 6,
+        },
+        shadowOpacity: 0.24,
+        shadowRadius: 12,
+        elevation: 5,
     },
     disableButton: {
-        backgroundColor: "#D9D9D9",
+        backgroundColor: "#C3CBD8",
+        shadowOpacity: 0,
+        elevation: 0,
     },
     submitButtonText: {
         color: "#FFFFFF",
         fontSize: 16,
-        fontWeight: "600",
+        fontWeight: "700",
     },
 });

--- a/src/features/search/components/AllSearchContent.tsx
+++ b/src/features/search/components/AllSearchContent.tsx
@@ -9,6 +9,7 @@ import {
     Image,
     StyleSheet,
     Text,
+    TouchableOpacity,
     View,
 } from "react-native";
 import type { PassportFeedItem } from "../types/passport.types";
@@ -39,6 +40,8 @@ export default function AllSearchContent({
     const [feedList, setFeedList] = useState<PassportFeedItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [isFetchingMore, setIsFetchingMore] = useState(false);
+    // 다음 페이지 로딩만 실패한 상태. 목록은 그대로 두고 재시도 수단만 띄운다.
+    const [loadMoreFailed, setLoadMoreFailed] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
     const [listHeight, setListHeight] = useState(0);
 
@@ -94,6 +97,8 @@ export default function AllSearchContent({
                 setErrorMessage("");
             }
 
+            setLoadMoreFailed(false);
+
             const result = await getPassportFeed({
                 size: 10,
                 cursor: isNextPage ? nextCursor : null,
@@ -112,6 +117,13 @@ export default function AllSearchContent({
         } catch (error) {
             console.log("피드 조회 에러:", error);
 
+            // 다음 페이지 요청이 실패했다고 보고 있던 목록까지 지우면 안 된다.
+            // 에러 화면으로 갈아치우면 스크롤 위치도 잃고 복구할 방법도 없다.
+            if (isNextPage) {
+                setLoadMoreFailed(true);
+                return;
+            }
+
             if (error instanceof Error) {
                 setErrorMessage(error.message);
             } else {
@@ -128,6 +140,9 @@ export default function AllSearchContent({
     }, []);
 
     const handleEndReached = () => {
+        // 실패 직후 자동 재요청이 반복되지 않게 한다. 사용자가 버튼으로 다시 시도한다.
+        if (loadMoreFailed) return;
+
         if (isLoading || isFetchingMore || !hasNext) {
             return;
         }
@@ -364,6 +379,16 @@ export default function AllSearchContent({
                     ListFooterComponent={
                         isFetchingMore ? (
                             <ActivityIndicator size="small" color="#1A3A6B" />
+                        ) : loadMoreFailed ? (
+                            <TouchableOpacity
+                                activeOpacity={0.8}
+                                style={styles.retryMoreButton}
+                                onPress={() => fetchFeed(true)}
+                            >
+                                <Text style={styles.retryMoreText}>
+                                    불러오지 못했어요. 다시 시도
+                                </Text>
+                            </TouchableOpacity>
                         ) : null
                     }
                 />
@@ -447,6 +472,17 @@ const styles = StyleSheet.create({
         borderRadius: 16,
         overflow: "hidden",
         zIndex: 1,
+    },
+    retryMoreButton: {
+        alignSelf: "center",
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+    },
+    retryMoreText: {
+        color: "#1A3A6B",
+        fontSize: 13,
+        fontWeight: "700",
+        textDecorationLine: "underline",
     },
     addMessageBox: {
         position: "absolute",

--- a/src/features/search/components/RankingContent.tsx
+++ b/src/features/search/components/RankingContent.tsx
@@ -98,30 +98,8 @@ export default function RankingContent({rankingMode}: RankingContentProps) {
 
     const topThree = rankingList.slice(0, 3);
 
-    if (isLoading) {
-        return (
-            <View style={styles.centerBox}>
-                <ActivityIndicator size="large" color="#1A3A6B" />
-            </View>
-        )
-    }
-
-    if (errorMessage) {
-        return (
-            <View style={styles.centerBox}>
-                <Text style={styles.errorText}>{errorMessage}</Text>
-            </View>
-        )
-    }
-
-    if(rankingList.length === 0) {
-        return(
-            <View style={styles.centerBox}>
-                <Text style={styles.emptyText}>아직 랭킹 데이터가 없습니다.</Text>
-            </View>
-        )
-    }
-
+    // 로딩·에러·빈 상태는 아래 본문에서 이미 처리한다.
+    // 여기서 조기 반환하면 구 선택 칩까지 사라져 다른 구를 고를 수 없게 된다.
     return (
         <View style={styles.container}>
             {rankingMode === "district" && (

--- a/src/features/team/screens/TeamScreen.tsx
+++ b/src/features/team/screens/TeamScreen.tsx
@@ -8,10 +8,7 @@
 import { useTeamMode } from "@/src/components/common/TeamModeContext";
 import { naverReverseGeocode } from "@/src/features/map/utils/mapUtils";
 import { Ionicons } from "@expo/vector-icons";
-import {
-    NaverMapMarkerOverlay,
-    NaverMapView,
-} from "@mj-studio/react-native-naver-map";
+import { useRouter } from "expo-router";
 import * as Securestore from "expo-secure-store";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -34,6 +31,7 @@ import type {
 const LIVE_LOCATION_POLL_INTERVAL_MS = 30 * 1000;
 
 export default function TeamView() {
+    const router = useRouter();
     const {
         clearTeamMode,
         currentUserId,
@@ -120,23 +118,49 @@ export default function TeamView() {
         }
     };
 
-    const handleLeaveTeam = () => {
+    const handleLeaveTeam = async () => {
         if (!team) return;
 
-        Alert.alert("팀 탈퇴", "정말로 팀에서 탈퇴하시겠어요?", [
+        // 팀장이 나가면 서버가 팀을 해산하고 팀 여권까지 전부 삭제한다
+        // (TeamService.leave -> disbandTeam). 같은 문구로 물으면 안 된다.
+        let isLeader = false;
+
+        try {
+            const memberList = members.length > 0
+                ? members
+                : await getTeamMembers(team.teamId);
+
+            isLeader = memberList.some(
+                (member) => member.userId === currentUserId && member.role === "LEADER",
+            );
+        } catch (error) {
+            console.log("팀 역할 확인 실패:", error);
+        }
+
+        const title = isLeader ? "팀 해산" : "팀 탈퇴";
+        const message = isLeader
+            ? "팀장이 나가면 팀이 해산됩니다.\n팀원 전원의 팀 여권이 모두 삭제되며 되돌릴 수 없습니다.\n계속할까요?"
+            : "정말로 팀에서 탈퇴하시겠어요?";
+
+        Alert.alert(title, message, [
             {
                 text: "취소",
                 style: "cancel",
             },
             {
-                text: "탈퇴하기",
+                text: isLeader ? "해산하기" : "탈퇴하기",
                 style: "destructive",
                 onPress: async () => {
                     try {
                         await leaveTeam(team.teamId);
                         clearTeamMode();
 
-                        Alert.alert("완료", "팀에서 탈퇴했습니다.");
+                        Alert.alert(
+                            "완료",
+                            isLeader
+                                ? "팀이 해산되었습니다."
+                                : "팀에서 탈퇴했습니다.",
+                        );
 
                         setTeam(null);
                         setMembers([]);
@@ -333,7 +357,7 @@ export default function TeamView() {
 
             <View style={styles.teamCard}>
                 <View style={styles.teamImage}>
-                    <Ionicons name="airplane" size={36} color="#1A3A6B" />
+                    <Ionicons name="people" size={34} color="#FFFFFF" />
                 </View>
 
                 <Text style={styles.teamName}>{team.teamName}</Text>
@@ -349,7 +373,7 @@ export default function TeamView() {
                         style={styles.codeActionButton}
                         onPress={handleCopyTeamCode}
                     >
-                        <Ionicons name="copy-outline" size={16} color="#1A3A6B" />
+                        <Ionicons name="copy-outline" size={16} color="#FFFFFF" />
                         <Text style={styles.codeActionText}>복사</Text>
                     </TouchableOpacity>
 
@@ -358,14 +382,9 @@ export default function TeamView() {
                         style={styles.codeActionButton}
                         onPress={handleShareTeamCode}
                     >
-                        <Ionicons name="share-social-outline" size={16} color="#1A3A6B" />
+                        <Ionicons name="share-social-outline" size={16} color="#FFFFFF" />
                         <Text style={styles.codeActionText}>공유</Text>
                     </TouchableOpacity>
-                </View>
-
-                <View style={styles.infoRow}>
-                    <Text style={styles.infoLabel}>팀 ID</Text>
-                    <Text style={styles.infoValue}>{team.teamId}</Text>
                 </View>
 
                 <View style={styles.infoRow}>
@@ -380,18 +399,22 @@ export default function TeamView() {
                 style={styles.menuItem}
                 onPress={handlePressMembers}
             >
-                <View style={styles.menuTitleRow}>
-                    <Text style={styles.menuTitle}>팀원 목록</Text>
-                    <Ionicons
-                        name={isMemberOpen ? "caret-up" : "caret-down"}
-                        size={18}
-                        color="#888888"
-                    />
+                <View style={styles.menuIconBox}>
+                    <Ionicons name="people-outline" size={22} color="#FFFFFF" />
                 </View>
 
-                <Text style={styles.menuDescription}>
-                    팀원들의 정보를 확인해요
-                </Text>
+                <View style={styles.menuTextArea}>
+                    <Text style={styles.menuTitle}>팀원 목록</Text>
+                    <Text style={styles.menuDescription}>
+                        팀원들의 정보를 확인해요
+                    </Text>
+                </View>
+
+                <Ionicons
+                    name={isMemberOpen ? "chevron-up" : "chevron-down"}
+                    size={20}
+                    color="#9CA3AF"
+                />
             </TouchableOpacity>
 
             {isMemberOpen && (
@@ -469,18 +492,22 @@ export default function TeamView() {
                 style={styles.menuItem}
                 onPress={handlePressLiveLocations}
             >
-                <View style={styles.menuTitleRow}>
-                    <Text style={styles.menuTitle}>실시간 위치</Text>
-                    <Ionicons
-                        name={isLocationOpen ? "caret-up" : "caret-down"}
-                        size={18}
-                        color="#888888"
-                    />
+                <View style={styles.menuIconBox}>
+                    <Ionicons name="location-outline" size={22} color="#FFFFFF" />
                 </View>
 
-                <Text style={styles.menuDescription}>
-                    지도에서 팀원들의 현재 위치를 확인해요
-                </Text>
+                <View style={styles.menuTextArea}>
+                    <Text style={styles.menuTitle}>실시간 위치</Text>
+                    <Text style={styles.menuDescription}>
+                        지도에서 팀원들의 현재 위치를 확인해요
+                    </Text>
+                </View>
+
+                <Ionicons
+                    name={isLocationOpen ? "chevron-up" : "chevron-down"}
+                    size={20}
+                    color="#9CA3AF"
+                />
             </TouchableOpacity>
 
             {isLocationOpen && (
@@ -513,53 +540,20 @@ export default function TeamView() {
                         </Text>
                     ) : (
                         <>
-                            <View style={styles.mapContainer}>
-                                <NaverMapView
-                                    style={styles.map}
-                                    initialCamera={{
-                                        latitude: visibleLiveLocations[0].latitude,
-                                        longitude: visibleLiveLocations[0].longitude,
-                                        zoom: 14,
-                                    }}
-                                    isNightModeEnabled={true}
-                                    lightness={-0.2}
-                                    isShowZoomControls={false}
-                                >
-                                    {visibleLiveLocations.map((location) => (
-                                        <NaverMapMarkerOverlay
-                                            key={location.userId}
-                                            latitude={location.latitude}
-                                            longitude={location.longitude}
-                                            anchor={{ x: 0.5, y: 1 }}
-                                            width={82}
-                                            height={84}
-                                        >
-                                            <View style={styles.liveMarker}>
-                                                {getLocationMember(location)?.profileImg ? (
-                                                    <Image
-                                                        source={{
-                                                            uri: getLocationMember(location)?.profileImg ?? "",
-                                                        }}
-                                                        style={styles.liveMarkerImage}
-                                                    />
-                                                ) : (
-                                                    <View style={styles.liveMarkerAvatar}>
-                                                        <Text style={styles.liveMarkerInitial}>
-                                                            {location.nickname.charAt(0)}
-                                                        </Text>
-                                                    </View>
-                                                )}
-                                                <Text
-                                                    style={styles.liveMarkerLabel}
-                                                    numberOfLines={1}
-                                                >
-                                                    {location.nickname}
-                                                </Text>
-                                            </View>
-                                        </NaverMapMarkerOverlay>
-                                    ))}
-                                </NaverMapView>
-                            </View>
+                            <TouchableOpacity
+                                activeOpacity={0.85}
+                                style={styles.openMapButton}
+                                onPress={() => router.push("/(tabs)")}
+                            >
+                                <Ionicons
+                                    name="map-outline"
+                                    size={17}
+                                    color="#FFFFFF"
+                                />
+                                <Text style={styles.openMapButtonText}>
+                                    지도에서 보기
+                                </Text>
+                            </TouchableOpacity>
 
                             <View style={styles.locationSummaryBox}>
                                 {visibleLiveLocations.map((location) => (
@@ -609,7 +603,7 @@ export default function TeamView() {
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        backgroundColor: "#FFFFFF",
+        backgroundColor: "#F8FAFD",
     },
     scrollContent: {
         paddingHorizontal: 20,
@@ -650,17 +644,26 @@ const styles = StyleSheet.create({
         marginBottom: 20,
     },
     teamCard: {
-        borderRadius: 24,
-        padding: 24,
-        backgroundColor: "#E5ECFC",
+        borderRadius: 18,
+        padding: 22,
+        backgroundColor: "#1A3A6B",
         alignItems: "center",
-        marginBottom: 20,
+        marginBottom: 22,
+
+        shadowColor: "#1A3A6B",
+        shadowOffset: {
+            width: 0,
+            height: 6,
+        },
+        shadowOpacity: 0.22,
+        shadowRadius: 14,
+        elevation: 5,
     },
     teamImage: {
-        width: 82,
-        height: 82,
-        borderRadius: 41,
-        backgroundColor: "#B2CAFF",
+        width: 72,
+        height: 72,
+        borderRadius: 36,
+        backgroundColor: "rgba(255, 255, 255, 0.16)",
         alignItems: "center",
         justifyContent: "center",
         marginBottom: 14,
@@ -673,28 +676,31 @@ const styles = StyleSheet.create({
     teamName: {
         fontSize: 22,
         fontWeight: "700",
-        color: "#111111",
-        marginBottom: 16,
+        color: "#FFFFFF",
+        marginBottom: 18,
+        textAlign: "center",
     },
     codeRow: {
         flexDirection: "row",
         alignItems: "center",
         backgroundColor: "#FFFFFF",
-        borderRadius: 16,
+        borderRadius: 14,
         paddingHorizontal: 16,
-        paddingVertical: 12,
-        marginBottom: 12,
+        paddingVertical: 14,
+        marginBottom: 10,
         width: "100%",
         justifyContent: "space-between",
     },
     codeLabel: {
-        fontSize: 14,
-        color: "#777777",
+        fontSize: 13,
+        fontWeight: "600",
+        color: "#6B7280",
     },
     codeValue: {
-        fontSize: 15,
-        fontWeight: "700",
-        color: "#2DC59F",
+        fontSize: 16,
+        fontWeight: "800",
+        color: "#1A3A6B",
+        letterSpacing: 1,
     },
     codeActionRow: {
         flexDirection: "row",
@@ -705,17 +711,15 @@ const styles = StyleSheet.create({
     codeActionButton: {
         flex: 1,
         height: 42,
-        borderRadius: 14,
-        borderWidth: 1,
-        borderColor: "#D7E0ED",
-        backgroundColor: "#FFFFFF",
+        borderRadius: 12,
+        backgroundColor: "rgba(255, 255, 255, 0.14)",
         flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
         gap: 6,
     },
     codeActionText: {
-        color: "#1A3A6B",
+        color: "#FFFFFF",
         fontSize: 13,
         fontWeight: "700",
     },
@@ -723,24 +727,45 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         justifyContent: "space-between",
         width: "100%",
-        paddingVertical: 8,
+        paddingTop: 12,
     },
     infoLabel: {
-        fontSize: 14,
-        color: "#777777",
+        fontSize: 13,
+        color: "rgba(255, 255, 255, 0.7)",
     },
     infoValue: {
-        fontSize: 14,
-        color: "#222222",
-        fontWeight: "500",
+        fontSize: 13,
+        color: "#FFFFFF",
+        fontWeight: "600",
     },
     menuItem: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 14,
         padding: 18,
         borderRadius: 18,
-        borderWidth: 1,
-        borderColor: "#EEEEEE",
         marginBottom: 12,
         backgroundColor: "#FFFFFF",
+
+        shadowColor: "#4c4c4c",
+        shadowOffset: {
+            width: 0,
+            height: 4,
+        },
+        shadowOpacity: 0.1,
+        shadowRadius: 12,
+        elevation: 3,
+    },
+    menuIconBox: {
+        width: 44,
+        height: 44,
+        borderRadius: 12,
+        backgroundColor: "#1A3A6B",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    menuTextArea: {
+        flex: 1,
     },
     menuTitleRow: {
         flexDirection: "row",
@@ -750,12 +775,12 @@ const styles = StyleSheet.create({
     menuTitle: {
         fontSize: 16,
         fontWeight: "700",
-        color: "#222222",
+        color: "#111827",
     },
     menuDescription: {
-        marginTop: 4,
+        marginTop: 3,
         fontSize: 13,
-        color: "#888888",
+        color: "#6B7280",
     },
     menuArrow: {
         fontSize: 13,
@@ -765,11 +790,18 @@ const styles = StyleSheet.create({
     memberListBox: {
         padding: 16,
         borderRadius: 18,
-        borderWidth: 1,
-        borderColor: "#EEEEEE",
         backgroundColor: "#FFFFFF",
         marginTop: -4,
         marginBottom: 12,
+
+        shadowColor: "#4c4c4c",
+        shadowOffset: {
+            width: 0,
+            height: 4,
+        },
+        shadowOpacity: 0.08,
+        shadowRadius: 12,
+        elevation: 2,
     },
     memberLoadingBox: {
         flexDirection: "row",
@@ -882,55 +914,20 @@ const styles = StyleSheet.create({
         color: "#5D6F89",
         lineHeight: 16,
     },
-    mapContainer: {
-        height: 240,
-        borderRadius: 16,
-        overflow: "hidden",
-        backgroundColor: "#101820",
-    },
-    map: {
-        width: "100%",
-        height: "100%",
-    },
-    liveMarker: {
+    // 팀원 실시간 위치는 메인 지도에 표시되므로 여기서는 그쪽으로 보낸다.
+    openMapButton: {
+        flexDirection: "row",
         alignItems: "center",
         justifyContent: "center",
-    },
-    liveMarkerAvatar: {
-        width: 46,
+        gap: 6,
         height: 46,
-        borderRadius: 23,
-        borderWidth: 3,
-        borderColor: "#FFFFFF",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "#FFE06E",
+        borderRadius: 14,
+        backgroundColor: "#1A3A6B",
+        marginBottom: 12,
     },
-    liveMarkerImage: {
-        width: 46,
-        height: 46,
-        borderRadius: 23,
-        borderWidth: 3,
-        borderColor: "#FFFFFF",
-        backgroundColor: "#E5ECFC",
-    },
-    liveMarkerInitial: {
-        color: "#111111",
-        fontSize: 16,
-        fontWeight: "800",
-    },
-    liveMarkerLabel: {
-        maxWidth: 70,
-        marginTop: 2,
-        paddingHorizontal: 6,
-        paddingVertical: 2,
-        borderRadius: 8,
-        overflow: "hidden",
-        borderWidth: 1,
-        borderColor: "#FFFFFF",
-        backgroundColor: "#FFE06E",
-        color: "#1A3A6B",
-        fontSize: 10,
+    openMapButtonText: {
+        color: "#FFFFFF",
+        fontSize: 14,
         fontWeight: "700",
     },
     locationSummaryBox: {
@@ -958,16 +955,15 @@ const styles = StyleSheet.create({
         color: "#999999",
     },
     leaveButton: {
-        height: 52,
-        borderRadius: 16,
-        borderWidth: 1,
-        borderColor: "#FF4D4F",
+        height: 44,
         alignItems: "center",
         justifyContent: "center",
+        marginTop: 4,
     },
     leaveButtonText: {
-        color: "#FF4D4F",
-        fontSize: 15,
-        fontWeight: "700",
+        color: "#9CA3AF",
+        fontSize: 13,
+        fontWeight: "600",
+        textDecorationLine: "underline",
     },
 });


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> QA

## 📝 작업 내용

앱 전 영역을 점검해 나온 결함 중 심각도 높은 것들을 수정했습니다.

#### 팀
- 부팅 시 `teamModeEnabled` 플래그만 보고 팀 모드를 복원해, 팀에서 나갔거나 팀이 사라진 뒤에도 **"팀에 가입된" 상태로 보이던 문제** — 이제 `getMyTeam` 으로 서버에 확인
- **팀 모드 해제가 아예 안 되던 문제** — 해제 경로의 `setLocationSharing` 예외로 `setIsTeamMode(false)` 까지 도달하지 못하고 있었습니다
- 로그아웃·세션 만료 시 토큰만 지우고 팀 캐시가 남아, **다음 계정에서 이전 계정의 팀이 보이던 문제**
- 팀 관리 모달이 로컬 캐시로 현재 팀을 판단하던 것을 서버 응답 기준으로 변경
- **팀장이 나가면 팀이 해산되고 팀원 전원의 여권이 삭제되는데** 확인창은 "정말로 팀에서 탈퇴하시겠어요?" 뿐이었습니다. 역할을 확인해 팀장이면 해산·삭제를 명시합니다
- 팀 관리 모달에 탈퇴 버튼 추가 (기존에는 팀 모드로 전환해 팀 페이지까지 가야 가능)
- 이미 팀에 속해 있으면 생성/가입 폼을 숨김

#### 여권
- **좋아요/스크랩 탭에서 연 남의 여권에 수정·삭제 버튼이 노출되던 문제** — `editable` 을 넘기지 않고 있었습니다
- 여권의 지역을 바꾸면 새로 만들고 원본을 지우는데 경고가 없어 **좋아요·스크랩이 사라졌습니다.** 확인 절차 추가
- 위 과정에서 원본 삭제만 실패하면 **같은 기록이 두 개** 남았습니다. 실패 시 생성분을 롤백
- 방문 날짜·주소는 서버 수정 API 가 받지 않는데(`PassportUpdateRequest` "위치/날짜 수정 불가") 앱은 수정된 것처럼 보여줬습니다. 저장되지 않는다고 안내
- 여권 상세에서 뒤로 왔을 때 빈 프리뷰 카드가 뜨던 문제

#### 둘러보기
- 피드 **다음 페이지 로딩이 한 번 실패하면 보고 있던 카드가 전부 사라지고** 재시도 수단도 없었습니다. 목록 유지 + 재시도 버튼
- 랭킹에 데이터가 없으면 **구 선택 칩까지 사라져 다른 구를 고를 수 없던 문제**

#### 네비게이션
- 프로필 수정·스크랩 등 하위 페이지에서 **뒤로가기가 항상 여권 탭으로 가던 문제** (`backBehavior="history"`)
- 프로필 수정 화면에서는 탭바를 숨김

#### UI
- 팀 페이지를 앱 톤에 맞춰 정리 (앱 팔레트에 없던 초록 팀코드 색 교체, 메뉴 카드 통일, 내부 식별자인 팀 ID 노출 제거)
- 팀 페이지의 실시간 위치 지도 제거 → 메인 지도로 이동하는 버튼으로 대체 (메인 지도가 이미 같은 정보를 표시해 지도가 두 개 떠 있었습니다)

## ⚠️ 남은 것

**신규 가입 온보딩이 100% 실패하는 문제는 이 PR에 없습니다.** `app/(auth)/signup.tsx:36` 이 정의되지 않은 `EXPO_PUBLIC_API_BASE_URL` 로 URL 을 만들어 `undefined/api/v1/users/me/onboarding` 로 요청이 나갑니다. 별도로 처리가 필요합니다.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다. (타입체크만 통과 — 팀장 탈퇴 경고, 지역 이동 롤백, 계정 전환은 실제 데이터 확인 필요)
