### PR TITLE
fix: 신규 가입 온보딩 저장이 항상 실패하던 문제 수정

### DIFF
--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,6 +1,7 @@
+import { getValidAccessToken } from "@/src/api/authToken";
+import { BASE_URL } from "@/src/api/config";
 import LighTripLogo from "@/src/constant/LighTrip.svg";
 import { useRouter } from "expo-router";
-import * as SecureStore from "expo-secure-store";
 import { useState } from "react";
 import {
   Alert,
@@ -30,10 +31,13 @@ export default function SignupScreen() {
     if (!isFormValid) return;
     setLoading(true);
     try {
-      const accessToken = await SecureStore.getItemAsync("accessToken");
+      // 이 화면만 EXPO_PUBLIC_API_BASE_URL 이라는 다른 이름의 환경변수를 쓰고 있었는데
+      // 그 변수는 어디에도 정의돼 있지 않아 요청이 "undefined/api/v1/..." 로 나갔다.
+      // 나머지 API 와 동일하게 config 의 BASE_URL 을 쓴다.
+      const accessToken = await getValidAccessToken();
 
       const response = await fetch(
-        `${process.env.EXPO_PUBLIC_API_BASE_URL}/api/v1/users/me/onboarding`,
+        `${BASE_URL}/api/v1/users/me/onboarding`,
         {
           method: "PATCH",
           headers: {


### PR DESCRIPTION
## 🔗 관련 이슈 (Related Issue)

> QA

## 📝 작업 내용

> **운영 앱에서 신규 가입자 전원이 겪는 문제입니다.**

온보딩 화면만 `EXPO_PUBLIC_API_BASE_URL` 이라는 **다른 이름의 환경변수**로 URL 을 만들고 있었는데, 그 변수는 `.env` 에도 `eas.json` 에도 정의돼 있지 않습니다. (레포 전체에서 이 변수를 쓰는 곳은 `signup.tsx` 한 곳, 정의하는 곳은 0곳)

```
요청 URL → undefined/api/v1/users/me/onboarding
```

RN 의 fetch 는 scheme 없는 URL 을 파싱하지 못해 항상 reject 되고, catch 로 빠져 "프로필 저장에 실패했어요" 알럿만 뜹니다. 나머지 API 는 `config.ts` 의 폴백(`https://api.lightrip.cloud`) 덕분에 정상 동작해서 이 화면만 조용히 깨져 있었습니다.

카카오·애플 모두 `isNewUser` 를 내려주고 앱이 그때 `/signup` 으로 보내므로 **모든 신규 가입자가 이 화면을 거칩니다.** 저장에 실패한 채 앱을 재실행하면 토큰은 있어 탭 화면에는 들어가지지만 닉네임·활동지역이 빈 계정이 됩니다.

#### 수정
- `src/api/config.ts` 의 `BASE_URL` 사용으로 통일
- 토큰도 만료 시 자동 재발급되는 `getValidAccessToken()` 으로 변경

배포 서버 스펙 확인 결과 엔드포인트(`PATCH /api/v1/users/me/onboarding`)와 요청 필드(`nickname`/`location`/`bio`)는 앱이 보내는 것과 일치합니다.

## ✅ PR 체크리스트

- [x] PR 제목은 커밋 컨벤션을 따랐습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 변경 사항에 대한 테스트를 진행했습니다. (타입체크 통과 / 신규 계정 가입 플로우 확인 필요)
